### PR TITLE
chore: RuboCop 設定を ginseng-style へ寄せる (#1515)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,119 +1,14 @@
+# 正本は pooza/ginseng-style の config/rubocop.yml。ここにはトマトすぐ死ぬ固有の差分だけを書く。
+# ⚠ 共通に見える緩和をここに足さないこと。共通化したい場合は pooza/ginseng-style に Issue を立てる。
+# ⚠ `bundle exec rubocop` で実行すること（inherit_gem は gem のパス解決に Bundler を使う）。
+inherit_gem:
+  ginseng-style: config/rubocop.yml
+
 plugins:
-  - rubocop-performance
-  - rubocop-minitest
-  - rubocop-rake
   - rubocop-sequel
 
 AllCops:
-  AllowSymlinksInCacheRootDirectory: true
-  DisplayCopNames: true
-  Exclude:
-    - '**/._*'
-    - '**/.git/**/*'
-    - public/**/*
-    - config/**/*
-    - tmp/**/*
-    - '**/old/**/*'
-  Include:
-    - '**/*.rb'
-    - '**/Rakefile'
-    - '**/config.ru'
-  NewCops: enable
   TargetRubyVersion: 3.4
-Layout/ArgumentAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/ArrayAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-Layout/EndAlignment:
-  EnforcedStyleAlignWith: variable
-Layout/EndOfLine:
-  EnforcedStyle: lf
-Layout/FirstArgumentIndentation:
-  EnforcedStyle: consistent
-Layout/FirstArrayElementIndentation:
-  EnforcedStyle: consistent
-Layout/FirstHashElementIndentation:
-  EnforcedStyle: consistent
-Layout/LineContinuationLeadingSpace:
-  EnforcedStyle: leading
-Layout/LineEndStringConcatenationIndentation:
-  EnforcedStyle: indented
-Layout/LineLength:
-  Exclude:
-    - test/*
-  Max: 100
-Layout/MultilineMethodCallIndentation:
-  EnforcedStyle: indented
-Layout/ParameterAlignment:
-  EnforcedStyle: with_fixed_indentation
-Layout/SpaceBeforeBlockBraces:
-  EnforcedStyle: space
-Layout/SpaceInsideBlockBraces:
-  EnforcedStyle: no_space
-  EnforcedStyleForEmptyBraces: no_space
-  SpaceBeforeBlockParameters: false
-Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
-Lint/AssignmentInCondition:
-  Enabled: false
-Lint/UnusedMethodArgument:
-  Enabled: false
-Metrics/AbcSize:
-  Exclude:
-    - test/*
-  Max: 30
-Metrics/BlockLength:
-  Exclude:
-    - test/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - app/task/**/*.rb
-    - '*.gemspec'
-Metrics/ClassLength:
-  Exclude:
-    - test/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - '**/service/*'
-  Max: 200
-Metrics/CyclomaticComplexity:
-  Exclude:
-    - test/*
-    - '**/contract/*'
-  Max: 10
-Metrics/MethodLength:
-  Exclude:
-    - test/*
-  Max: 20
-Metrics/ModuleLength:
-  Exclude:
-    - test/*
-    - '**/contract/*'
-    - '**/controller/*'
-    - '**/service/*'
-  Max: 200
-Metrics/PerceivedComplexity:
-  Exclude:
-    - test/*
-    - '**/contract/*'
-  Max: 10
-Minitest/MultipleAssertions:
-  Enabled: false
-Minitest/ReturnInTestMethod:
-  Enabled: false
-Minitest/TestFileName:
-  Enabled: false
-Naming/RescuedExceptionsVariableName:
-  PreferredName: e
-Rake:
-  Exclude:
-    - '*'
-  Include:
-    - Rakefile
-    - '*.rake'
-    - app/task/**/*.rb
 Sequel:
   Exclude:
     - '*'
@@ -123,44 +18,4 @@ Sequel:
 Sequel/ConcurrentIndex:
   Enabled: false
 Sequel/IrreversibleMigration:
-  Enabled: false
-Style/AsciiComments:
-  Enabled: false
-Style/ConditionalAssignment:
-  Enabled: false
-Style/Documentation:
-  Enabled: false
-Style/EmptyMethod:
-  EnforcedStyle: expanded
-Style/FormatString:
-  EnforcedStyle: percent
-Style/FormatStringToken:
-  EnforcedStyle: template
-Style/FrozenStringLiteralComment:
-  Enabled: false
-Style/IdenticalConditionalBranches:
-  Exclude:
-    - test/*
-Style/IfUnlessModifier:
-  Exclude:
-    - test/*
-Style/RedundantReturn:
-  Enabled: false
-Style/RescueModifier:
-  Enabled: false
-Style/RescueStandardError:
-  Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
-Style/SymbolArray:
-  EnforcedStyle: brackets
-Style/TrailingCommaInArguments:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArrayLiteral:
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInHashLiteral:
-  EnforcedStyleForMultiline: comma
-Style/WordArray:
-  EnforcedStyle: brackets
-Style/YodaCondition:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -20,11 +20,8 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
+  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
   gem 'ricecream'
-  gem 'rubocop'
-  gem 'rubocop-minitest'
-  gem 'rubocop-performance'
-  gem 'rubocop-rake'
   gem 'rubocop-sequel'
   gem 'test-unit'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,17 @@ GIT
     ginseng-piefed (0.1.1)
 
 GIT
+  remote: https://github.com/pooza/ginseng-style.git
+  revision: 2474936f5598640c9cf8464f71195c2bb03e4309
+  branch: main
+  specs:
+    ginseng-style (1.0.0)
+      rubocop
+      rubocop-minitest
+      rubocop-performance
+      rubocop-rake
+
+GIT
   remote: https://github.com/pooza/ginseng-youtube.git
   revision: 453a25139a2de765c6f9ad03d450f5053bddfcba
   branch: main
@@ -306,6 +317,7 @@ DEPENDENCIES
   ginseng-core!
   ginseng-fediverse!
   ginseng-piefed!
+  ginseng-style!
   ginseng-youtube!
   icalendar
   icalendar-rrule!
@@ -315,10 +327,6 @@ DEPENDENCIES
   parallel
   puma
   ricecream
-  rubocop
-  rubocop-minitest
-  rubocop-performance
-  rubocop-rake
   rubocop-sequel
   rufus-scheduler
   sentry-ruby

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -607,12 +607,21 @@ test/                  # テストファイル
 
 ## コーディング規約
 
-- RuboCop に準拠（`.rubocop.yml`）
+⚠ **正本は [pooza/ginseng-style](https://github.com/pooza/ginseng-style)。** ここに書き写さないこと。
+
+| ドキュメント | 内容 |
+| --- | --- |
+| [docs/ruby.md](https://github.com/pooza/ginseng-style/blob/main/docs/ruby.md) | Ruby の書き方（暗黙の return を使わない、テストの `disable?` パターン、文字列のエンコーディング） |
+| [docs/workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) | Issue 駆動・ブランチ・サイズラベル・リリース前レビュー・`ginseng-*` の変更手順 |
+| [docs/writing.md](https://github.com/pooza/ginseng-style/blob/main/docs/writing.md) | 表記規約（用語・パスとキーの書き方・⚠ マーカーの使い方） |
+| [docs/rationale.md](https://github.com/pooza/ginseng-style/blob/main/docs/rationale.md) | なぜ正本化したか |
+
+RuboCop の設定も同じ gem が持つ（`.rubocop.yml` は `inherit_gem` で差分だけ）。⚠ **共通に見える緩和をこちら側に足さないこと。** 共通化したい場合は ginseng-style に Issue を立てる。
+
+トマトすぐ死ぬ固有:
+
 - テスト: test-unit (`TomatoShrieker::TestCase` 基底クラス)
-- 文字列: シングルクォート
-- メソッド末尾でも `return` を省略しない
-- 行長: 100文字（テストファイルは除外）
-- 末尾カンマ: 複数行では付与
+- `.rubocop.yml` に残している差分は `TargetRubyVersion` と `rubocop-sequel`（`Sequel/*`）だけ
 
 ### 例外メッセージは `Package.error_message` を通す
 


### PR DESCRIPTION
closes #1515

`.rubocop.yml` を [pooza/ginseng-style](https://github.com/pooza/ginseng-style) から `inherit_gem` する形に移した。**166 行 → 21 行**、固有差分として残したのは `TargetRubyVersion` と `rubocop-sequel`（`Sequel/*`）の 2 つ。

## ⚠ 経緯（このリポジトリだけを見ても分からないので書く）

`.rubocop.yml` を持つ **22 リポジトリ**のうち **10 本が 153 行完全一致**で、本質的な差は 3 つだけだった（`TargetRubyVersion` / `Style/FrozenStringLiteralComment` / プロジェクト固有プラグイン）。

🔴 **drift の実害**: `Exclude: test/*` を `test/**/*` に直したのは 1 リポジトリだけで、**残り 17 リポジトリでは入れ子のテストに除外が効いていなかった**。⚠ このリポジトリも `test/*` のままだった。

⚠⚠ 壊れているのは「手で直す手間」ではなく **「直した変更が全員に届いたかを誰も見ていない」**こと。詳細は [ginseng-style の docs/rationale.md](https://github.com/pooza/ginseng-style/blob/main/docs/rationale.md)、横断の受け皿は pooza/ginseng-style#1。`ginseng-*` の gem 側 7 本は移行済み。

## 変更

- `.rubocop.yml` を `inherit_gem` ＋ 固有差分だけに
- `Gemfile`: rubocop 本体と `rubocop-minitest` / `rubocop-performance` / `rubocop-rake` を外し、`ginseng-style` を development group へ。⚠⚠ **`rubocop-sequel` は正本が抱えていないので残す**
- `docs/CLAUDE.md` の「コーディング規約」を正本へのポインタに置換（トマトすぐ死ぬ固有の記述は残した）。⚠ **次にこのリポジトリを開くセッションが、聞かずに正本へ辿り着けるようにするため**
- `Gemfile.lock`: rubocop 系が直接依存から `ginseng-style` の依存へ移るだけ

## ✅ 検証

- **`bundle exec rubocop --show-cops` の差分ゼロ** — ロードされる cop は移行前と同じ **724 個**で顔ぶれも完全一致（`Sequel/*` 6 件を含む）
- `bundle exec rubocop` 緑（85 files, no offenses）
- `bundle exec rake migration:run` → `CI=true bundle exec rake test` が **207 tests / 389 assertions / 0 failures / 0 errors / 2 omissions**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
