### PR TITLE
chore: ginseng-* を追随する (#1518, #1517)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 4b134cebaf80c6ba0267363d5f729b59bdaf6c36
+  revision: e445a60500fc8ebd50a4ef4c7a20f032dd927ef5
   branch: main
   specs:
-    ginseng-core (1.15.28)
+    ginseng-core (1.19.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -22,7 +22,7 @@ GIT
       net-smtp
       nokogiri (>= 1.18.9)
       optparse
-      rake (< 13.4)
+      rake (!= 13.4.0)
       sanitize (>= 6.0.2)
       securerandom
       set
@@ -34,14 +34,14 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 60a38dae2e80096734e408ced2d322b994e4c624
+  revision: 9b2fdd584ef72de24ff860dd10803cee00bddf8b
   branch: main
   specs:
-    ginseng-fediverse (1.8.25)
+    ginseng-fediverse (1.8.28)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: 56208ffd262652788eb0a3d2ff8e34df410d0b0f
+  revision: 4c8b94d71eb85fcc77e728c1ff1416100cc545d7
   branch: main
   specs:
     ginseng-piefed (0.1.1)
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: 453a25139a2de765c6f9ad03d450f5053bddfcba
+  revision: b27af86e1a9e60bf254fb06ebebb771575d6ffa1
   branch: main
   specs:
     ginseng-youtube (2.0.1)
@@ -112,7 +112,7 @@ GEM
     ecdsa (1.2.0)
     ecdsa_ext (0.5.1)
       ecdsa (~> 1.2.0)
-    erb (6.0.6)
+    erb (6.0.7)
     et-orbi (1.4.1)
       tzinfo
     etc (1.4.6)
@@ -218,7 +218,7 @@ GEM
     raabro (1.5.0)
     racc (1.8.1)
     rainbow (3.1.1)
-    rake (13.3.1)
+    rake (13.4.2)
     regexp_parser (2.12.0)
     rexml (3.4.4)
     ricecream (0.2.1)
@@ -298,7 +298,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     yajl-ruby (1.4.3)
-    zeitwerk (2.8.2)
+    zeitwerk (2.8.3)
     zlib (3.2.3)
 
 PLATFORMS

--- a/Rakefile
+++ b/Rakefile
@@ -5,4 +5,7 @@ require 'tomato_shrieker'
 module TomatoShrieker
   Sequel.connect(Environment.dsn)
   load_tasks
+  # ⚠ **`environment:` を渡すこと (#1517)。**既定は `Ginseng::Environment` ＝ gem の
+  # ルートを指すので、`cert:update` が gem 側に cert/cacert.pem を作ってしまう。
+  Ginseng.load_tasks(environment: Environment)
 end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -19,6 +19,10 @@ http:
   retry:
     limit: 3
     seconds: 1
+  # ⚠ ginseng-core 1.19.0 の HTTP#initialize が必須で読む (`/http/timeout/seconds`)。
+  # 既定へ倒れないので、無いと HTTP を作った時点で ConfigError になる。
+  timeout:
+    seconds: 30
 line:
   urls:
     api: https://api.line.me


### PR DESCRIPTION
#1518 の本体側。サテライト 3 本（`loquat` / `shooby-do-bop` / `dqdai-anniv`）は別途。

## 変更

| gem | before | after |
| --- | --- | --- |
| ginseng-core | 1.15.28 (`4b134ce`) | **1.19.0** (`e445a60`) |
| ginseng-fediverse | 1.8.25 (`60a38da`) | 1.8.28 (`9b2fdd5`) |
| ginseng-piefed | `56208ff` | `4c8b94d` |
| ginseng-youtube | `453a251` | `b27af86` |

## 🔴 `/http/timeout/seconds` が必須になっていた

ginseng-core 1.19.0 の `HTTP#initialize` は `@timeout = @config['/http/timeout/seconds']` を読む。⚠ **`/http/retry/max_seconds` は `rescue ConfigError` で既定へ倒れるのに、こちらは倒れない。**無いと **HTTP を作った時点で `Ginseng::ConfigError`**＝ローカルで **25 failures / 90 errors**（`FeedSource#initialize` が全滅）。

`mulukhiya-toot-proxy` / `makoto2` は同じキーを持っており、**tomato だけ追随の谷間で持っていなかった**。値は両者に合わせて `30`。

## #1517 も同時に

`Rakefile` に `Ginseng.load_tasks(environment: Environment)` を足し、`cert:update` / `cert:check` が生えることを確認した。⚠ **`environment:` を省くと `Ginseng::Environment` ＝ gem のルートに cert を作る**ので明示している。

⚠ **`cert/cacert.pem` を持つかどうかはこの PR では決めていない。**持たない状態は上流 #512 の修正により無害（OS の CA ストアに倒れる）。`rake cert:check` は「not fresh」と言うが、CI からは呼んでいない。

## 検証

- `bundle exec rake test` — **207 tests / 865 assertions / 0 failures / 0 errors**
- `bundle exec rubocop` — **85 files 無指摘**

### ⚠ omission が 2 → 12 に増えた（後退ではない）

上流 ginseng-core #488 で **`disable?` のケースが pass ではなく omission として報告される**ようになったため。**中身は「これまで緑に見えていたが実際には走っていなかった 10 件」**で、Line / Mastodon / Misskey / Nostr / Piefed の各 `test_exec` / `test_templates`。⚠ **Mastodon / Misskey の直接経路は docs で「テスト責任を持つ中核機能」と位置づけているものなので、別 Issue にする。**

## 本番デプロイ後に見るもの

⚠ **「検証で通した IP へ接続する」(#503) が入っている**ので、壊れるならここ。

- `/status.json` の `last_status` / `undelivered`
- ログの `Bad response` の内訳（新しい壊れ方が出ていないか）
