### PR TITLE
fix: PiefedShrieker の login を投稿時へ遅らせる (#1514)

### DIFF
--- a/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
@@ -5,7 +5,6 @@ module TomatoShrieker
       params[:url] = "https://#{params[:host]}" if params[:host] && !params[:url]
       params[:user] = params[:user_id] if params[:user_id] && !params[:user]
       super
-      login
     end
 
     def api_version
@@ -13,6 +12,11 @@ module TomatoShrieker
     end
 
     def exec(body)
+      # ⚠ **構築時ではなくここで login する (#1514)。**上流の `Service#login` は
+      # `return if @jwt` を持つので、二重に叩くことはない。構築時に無条件で叩くと、
+      # 投稿しないケース（設定の読み込み・`source list`・テストの初期化）でも
+      # PieFed の認証 API を叩き、レートリミット (429) を踏みやすくなる。
+      login
       template = create_piefed_template(body[:template])
       data = {
         title: template.to_s.gsub(/[\r\n[:blank:]]+/, ' '),

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -181,17 +181,20 @@ curl -sS "https://pf.korako.me/api/alpha/post/list?community_id=82&sort=New&limi
 
 ⚠ **`curl` や Python の urllib で `/api/alpha/user/login` を直接叩いて確かめようとしないこと。**Cloudflare が弾いて **HTTP 403 (error code 1010)** を返し、認証失敗と見分けが付かない。必ず下記のようにアプリの HTTP クライアント経由で確認する（2026-08-03 に踏んだ）。なお `/api/alpha/post/list` のような GET は `curl` でも通る。
 
+⚠ **4.7.0 (#1514) から login は遅延する。**構築しただけでは `@jwt` は `absent` のままなので、**明示的に `login` を呼んでから見る**こと。
+
 ```sh
 bundle exec ruby -Iapp/lib -rtomato_shrieker -e '
 include TomatoShrieker
 Sequel.connect(Environment.dsn)
 src = Source.create("test-google-news-piefed")
 shr = src.piefed
+shr.login
 puts "JWT: #{shr.instance_variable_get(:@jwt) ? "present" : "absent"}"
 '
 ```
 
-JWT が `present` なら login 成功。`absent` なら認証情報が古い等の可能性。
+JWT が `present` なら login 成功。`Ginseng::AuthError` が上がるなら認証情報が古い等の可能性。
 
 ## チェックリスト
 

--- a/test/piefed_shrieker.rb
+++ b/test/piefed_shrieker.rb
@@ -20,3 +20,53 @@ module TomatoShrieker
     end
   end
 end
+
+module TomatoShrieker
+  # ⚠ 上の PiefedShriekerTest は dest に piefed を持つテスト用ソースが手元に無いと
+  # `disable?` で丸ごと落ちる (#1520)。login の遅延だけは環境に依らず見たいので、
+  # webmock で閉じた独立のテストケースにする。
+  class PiefedShriekerLoginTest < TestCase
+    PARAMS = {
+      host: 'piefed.example.com',
+      user_id: 'user@example.com',
+      password: 'password',
+      community_id: 1,
+    }.freeze
+
+    def setup
+      WebMock.enable!
+      WebMock.disable_net_connect!
+      @stub = stub_request(:post, %r{/user/login}).to_return(
+        status: 200,
+        body: '{"jwt":"dummy"}',
+        headers: {'Content-Type' => 'application/json'},
+      )
+    end
+
+    def teardown
+      WebMock.allow_net_connect!
+      WebMock.disable!
+      super
+    end
+
+    # #1514: 構築時に無条件で login すると、投稿しないケース（設定の読み込み・
+    # source list・テストの初期化）でも認証 API を叩き、429 を踏みやすくなる。
+    def test_does_not_login_on_initialize
+      PiefedShrieker.new(PARAMS)
+      assert_not_requested(@stub)
+    end
+
+    def test_logs_in_on_demand
+      shrieker = PiefedShrieker.new(PARAMS)
+      shrieker.login
+      assert_requested(@stub, times: 1)
+    end
+
+    # ⚠ 上流の Service#login は `return if @jwt` を持つ。exec のたびに叩き直さない。
+    def test_does_not_login_twice
+      shrieker = PiefedShrieker.new(PARAMS)
+      2.times {shrieker.login}
+      assert_requested(@stub, times: 1)
+    end
+  end
+end

--- a/test/piefed_shrieker.rb
+++ b/test/piefed_shrieker.rb
@@ -53,12 +53,14 @@ module TomatoShrieker
     # source list・テストの初期化）でも認証 API を叩き、429 を踏みやすくなる。
     def test_does_not_login_on_initialize
       PiefedShrieker.new(PARAMS)
+
       assert_not_requested(@stub)
     end
 
     def test_logs_in_on_demand
       shrieker = PiefedShrieker.new(PARAMS)
       shrieker.login
+
       assert_requested(@stub, times: 1)
     end
 
@@ -66,6 +68,7 @@ module TomatoShrieker
     def test_does_not_login_twice
       shrieker = PiefedShrieker.new(PARAMS)
       2.times {shrieker.login}
+
       assert_requested(@stub, times: 1)
     end
   end


### PR DESCRIPTION
上流（`Ginseng::Piefed::Service`）は `login` に `return if @jwt` を持ち、`clip` でも `login unless @jwt` と遅延させている。⚠ **こちら側の `initialize` だけが無条件に `login` を足していた**＝上流の方針を打ち消す逸脱。

## 直したこと

- `initialize` から `login` を外し、`exec` の先頭で呼ぶ
- ⚠ **上流の `login` は `return if @jwt` を持つので、exec のたびに叩き直さない**

## 効果

- 投稿しないケース（設定の読み込み・`source list`・テストの初期化）で認証 API を叩かなくなる＝**429 を踏みにくくなる**。`rake test` が実サーバーへ何度も login する問題 (#1468) も軽くなる
- ⚠ **失敗の見え方が変わる。**認証に失敗したとき、これまでは構築時に例外 → アクセサが nil → **`record_unavailable`（宛先が消えた扱い）**だったが、遅延させると投稿時の **`record_error`** になり、**真因が監視に出る**

## テスト

webmock で閉じた独立のテストケース `PiefedShriekerLoginTest` を追加した（3 件）。⚠ **既存の `PiefedShriekerTest` は dest に piefed を持つソースが手元に無いと `disable?` で丸ごと落ちる (#1520) ので、そちらには足せない。**

**`initialize` に `login` を戻すと `test_does_not_login_on_initialize` が落ちる**ことを確認済み（テストが空振りしていないことの確認）。

- `rake test` 210 tests / 0 failures / 0 errors
- `rubocop` 85 files 無指摘（⚠ **初回は指摘 3 件**。テストを書く前に流していたので新しいファイルを見ておらず、CI で `Minitest/EmptyLineBeforeAssertionMethods` を検出した。追従済み）

## docs

[release-validation.md](docs/release-validation.md) の「PieFed 認証単独テスト」は構築しただけで `@jwt` を見ていたので、**明示的に `login` を呼ぶ**手順に直した。

## ⚠ 観測した揺らぎ（本 PR とは無関係）

検証中に `SourceRunLogTest#test_prune_keeps_first_run_row` が **1 度だけ** 落ちた。同じコードで前後の実行では再現しない。⚠ **本番の prune に関わるテストなので、再発したら Issue にする。**