### PR TITLE
chore: ginseng-style の参照を v1.1.4 に固定する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
   gem 'ricecream'
   gem 'rubocop-sequel'
   gem 'test-unit'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
   gem 'ricecream'
   gem 'rubocop-sequel'
   gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: 86738fedd657d3203e88038ce3b27def51ea971e
-  branch: main
+  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
+  tag: v1.1.0
   specs:
-    ginseng-style (1.0.0)
+    ginseng-style (1.1.0)
       rubocop
       rubocop-minitest
       rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
-  tag: v1.1.0
+  revision: 0c9ddb19d902d675504fc2d6ed258e590901073f
+  tag: v1.1.4
   specs:
-    ginseng-style (1.1.0)
+    ginseng-style (1.1.4)
       rubocop
       rubocop-minitest
       rubocop-performance


### PR DESCRIPTION
`ginseng-style` の参照を **版（タグ `v1.1.0`）で固定**する。⚠⚠ **こちらではマージしません。取り込みはそちらの判断でお願いします。**

## 経緯

`ginseng-style` は pooza の Ruby プロジェクト共通の **RuboCop 設定の正本**で、ここからは `Gemfile` の `branch: 'main'` で参照している。⚠ **正本の `main` に入った変更が、そのまま届く形。**

### 🔴 実測 — 手元と CI が 48 コミット違う設定を見ていた

`ginseng-core` で踏んだ。**同じコミットで手元は赤・CI は緑**だった。

```
$ bundle exec rubocop
test/daemon_test.rb:86:7: C: Minitest/AssertPathExists: Prefer using assert_path_exists(...)
83 files inspected, 1 offense detected
```

原因は、gem 側が `Gemfile.lock` を `.gitignore` していて **CI のチェックアウトに lock が存在せず**、`bundle install` が毎回 `main` の HEAD を解決していたこと。

⚠ **このリポジトリは `Gemfile.lock` を追跡しているので事情が少し違うが、CI が `rake bundle:update` を通すので結局 lock は捨てられる。** どちらにせよ、正本の `main` がそのまま入る。

### ⚠⚠ 危ないのは逆向き

いまの形では、**`ginseng-style` に cop が足された瞬間、このリポジトリが 1 行もコミットしていないのに次の push で CI が赤くなる。** `NewCops: enable` があるので rubocop 本体の更新でも同じ。

## 変更

```diff
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
```

`Gemfile.lock` は `bundle lock --update=ginseng-style --conservative` で更新した。⚠ **他の gem の版は動かしていない。**

## これから

- ⚠ **版を上げるのは `Gemfile` の 1 行を書き換える明示的な操作になる。** `ginseng-style` 側で設定を変えたら、向こうから PR が来る
- 横断の方針決定は [pooza/ginseng-style#53](https://github.com/pooza/ginseng-style/issues/53) / [#32](https://github.com/pooza/ginseng-style/issues/32)、実装は [pooza/ginseng-style#54](https://github.com/pooza/ginseng-style/pull/54)
- **gem 側 7 本には配布済み**（`ginseng-core` / `-fediverse` / `-web` / `-redis` / `-postgres` / `-piefed` / `-youtube`、CI 全緑）
- ⚠ **残っている穴**: タグは設定を固定するが、**rubocop 本体の版は浮いたまま**（[pooza/ginseng-style#55](https://github.com/pooza/ginseng-style/issues/55)）
