### PR TITLE
chore: ginseng-* を追随する (#1524)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: e445a60500fc8ebd50a4ef4c7a20f032dd927ef5
+  revision: 8443ae749e35a49a49751828f4e58c522c8d1eb8
   branch: main
   specs:
-    ginseng-core (1.19.0)
+    ginseng-core (1.20.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -34,14 +34,14 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 9b2fdd584ef72de24ff860dd10803cee00bddf8b
+  revision: 8b23e095d68674d18840ea782c15c560202f3adb
   branch: main
   specs:
-    ginseng-fediverse (1.8.28)
+    ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: 4c8b94d71eb85fcc77e728c1ff1416100cc545d7
+  revision: 1150891191edb02dbbc60153a375b1756b0bd943
   branch: main
   specs:
     ginseng-piefed (0.1.1)
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: b27af86e1a9e60bf254fb06ebebb771575d6ffa1
+  revision: f041de996b98a6d24df07c5fcd70893290206f68
   branch: main
   specs:
     ginseng-youtube (2.0.1)


### PR DESCRIPTION
closes #1524

| gem | 前 | 後 | 遅れ |
| --- | --- | --- | --- |
| `ginseng-core` | 1.19.0 (`e445a60`) | **1.20.0** (`8443ae7`) | 21 |
| `ginseng-fediverse` | 1.8.28 (`9b2fdd5`) | **1.8.31** (`8b23e09`) | 23 |
| `ginseng-piefed` | `4c8b94d` | `1150891` | 7 |
| `ginseng-youtube` | `b27af86` | `f041de9` | 9 |

4 本とも上流 `main` の先頭に並んだ（`compare` の `ahead_by` が全部 0）。

## ✅ 必須の設定キーは増えていない

🔴 **前回（#1518）は `/http/timeout/seconds` が必須になっており、無いと HTTP を作った時点で `ConfigError` だった。**今回は同じ罠が無いことを先に確かめた。

`config['...']` で読むキーの集合を新旧で突き合わせ、**`ginseng-core` / `ginseng-fediverse` / `ginseng-piefed` とも差分ゼロ**。`rake test` も **210 tests / 0 failures / 0 errors**、RuboCop も 85 files 無指摘。

## ⚠ 本 PR で tomato の挙動が変わる経路はほぼ無い

取り込んだ修正のうち、**実際にこのアプリが通る経路にあるのは資格情報の落とし忘れ 3 件だけ**。

- **[#527](https://github.com/pooza/ginseng-core/issues/527) / [#568](https://github.com/pooza/ginseng-core/issues/568) / [#576](https://github.com/pooza/ginseng-core/issues/576)** — リダイレクト追従で **query / `basic_auth` / `digest_auth` / `cookies` が別オリジンへ渡っていた**。⚠ **認証付きフィード URL を持つので該当しうる**（#1511 が同じ資産を扱っている）
- **[#569](https://github.com/pooza/ginseng-core/issues/569)（`post` / `put` / `delete` / `upload` の `host_validator`）は no-op。**⚠ **`host_validator` は opt-in で、tomato はどこからも渡していない**ことを確認済み（`app/` に 1 件も無い）
- **`ginseng-fediverse` の `media_attributes` JSON 化 / `X-Mulukhiya` の付与は `update_status`（PUT）だけ**で、tomato は新規投稿と `upload_remote_resource` しか叩かないので通らない
- `create_headers` が渡された hash を複製する（[#256](https://github.com/pooza/ginseng-fediverse/issues/256) / [#258](https://github.com/pooza/ginseng-fediverse/issues/258)）＝**設定のトークンが呼び側に残らない**。防御的な変更

そのほか、ログ（`info` / `error` のブロック形式、raise していない例外のバックトレース展開）と `TagContainer` の UTF-8 保証が入っている。

## ⚠ サテライト 3 本

`loquat` / `shooby-do-bop` / `dqdai-anniv` も同じ 21 コミット遅れなので、**同じサイクルで別 PR を出す**。⚠ **本体だけ追随すると CommandSource の 7 ソースだけ古い gem で動き続ける。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)