### PR TITLE
4.6.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
   gem 'ricecream'
   gem 'rubocop-sequel'
   gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: e445a60500fc8ebd50a4ef4c7a20f032dd927ef5
+  revision: 8443ae749e35a49a49751828f4e58c522c8d1eb8
   branch: main
   specs:
-    ginseng-core (1.19.0)
+    ginseng-core (1.20.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -34,24 +34,24 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 9b2fdd584ef72de24ff860dd10803cee00bddf8b
+  revision: 8b23e095d68674d18840ea782c15c560202f3adb
   branch: main
   specs:
-    ginseng-fediverse (1.8.28)
+    ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: 4c8b94d71eb85fcc77e728c1ff1416100cc545d7
+  revision: 1150891191edb02dbbc60153a375b1756b0bd943
   branch: main
   specs:
     ginseng-piefed (0.1.1)
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: 2474936f5598640c9cf8464f71195c2bb03e4309
-  branch: main
+  revision: 0c9ddb19d902d675504fc2d6ed258e590901073f
+  tag: v1.1.4
   specs:
-    ginseng-style (1.0.0)
+    ginseng-style (1.1.4)
       rubocop
       rubocop-minitest
       rubocop-performance
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: b27af86e1a9e60bf254fb06ebebb771575d6ffa1
+  revision: f041de996b98a6d24df07c5fcd70893290206f68
   branch: main
   specs:
     ginseng-youtube (2.0.1)
@@ -222,7 +222,7 @@ GEM
     regexp_parser (2.12.0)
     rexml (3.4.4)
     ricecream (0.2.1)
-    rubocop (1.88.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -240,9 +240,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-performance (1.26.1)
+    rubocop-performance (1.27.0)
       lint_roller (~> 1.1)
-      rubocop (>= 1.75.0, < 2.0)
+      rubocop (>= 1.89.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -47,7 +47,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.6.1
+  version: 4.6.2
 nostr:
   relays:
     - wss://relay.damus.io


### PR DESCRIPTION
上流 `ginseng-*` の security 修正を取り込むためのパッチリリース。**機能の変更はありません。**（#1524 / develop の #1526 と同じ内容）

## security

### 🔴 資格情報が別オリジンへ渡る穴が 3 件（`ginseng-core` 1.19.0 → **1.20.0**）

- [#527](https://github.com/pooza/ginseng-core/issues/527) — **リダイレクト追従で初段の query を撃ち直し、別オリジンへ資格情報を渡していた**
- [#568](https://github.com/pooza/ginseng-core/issues/568) — 別オリジンへのリダイレクトで **`basic_auth` / `digest_auth` が落ちていなかった**
- [#576](https://github.com/pooza/ginseng-core/issues/576) — 同じく **`cookies:` オプションが落ちていなかった**

⚠ **認証付きフィード URL を持つので、該当しうる経路がある**（#1511 が同じ資産を扱っている）。

### SSRF ガードの穴

- [#569](https://github.com/pooza/ginseng-core/issues/569) — `post` / `put` / `delete` / `upload` で `host_validator` が効いていなかった／`Location` 付きの 304 を追わない。⚠ **tomato は `host_validator` をどこからも渡していないので no-op**

### 設定のトークンが呼び側に残っていた（`ginseng-fediverse` 1.8.28 → **1.8.31**）

- [#256](https://github.com/pooza/ginseng-fediverse/issues/256) / [#258](https://github.com/pooza/ginseng-fediverse/issues/258) — `create_headers` が渡された headers hash を破壊的に書き換えていた

そのほか `ginseng-piefed` / `ginseng-youtube` も上流の先頭へ。ログ（`info` / `error` のブロック形式）と `TagContainer` の UTF-8 保証も入っています。

## ✅ 必須の設定キーは増えていない

🔴 **前回（v4.6.1）は `/http/timeout/seconds` が必須になっており、無いと HTTP を作った時点で `ConfigError` だった。**今回は `config['...']` で読むキーの集合を新旧で突き合わせ、**差分ゼロ**を確認済み。

## 検証

- **RuboCop 無指摘**（85 files）
- **リダイレクト追従で query が保たれることを実機で確認**（`302` → 200・`args.foo == "bar"`）。⚠ 落とすのは**初段の資格情報を別オリジンへ**運ぶ場合だけで、正常なリダイレクトは壊れていない
- `bin/shrieker source fetch` で **GitHubRepositorySource / GoogleNewsSource / IcalendarSource** が取得できることを確認（いずれもリダイレクトを挟む経路）
- ⚠ **`rake test` は YouTube の間欠 404 で 3〜4 errors 出るが、`main` ＋ 旧 gem でも同数**。本 PR による後退ではない（同時刻に `curl` でも 404 が返っている）

## ⚠ サテライト 3 本も同時にデプロイが必要

`loquat` / `shooby-do-bop` / `dqdai-anniv` も同じ追随を入れてマージ済み（pooza/loquat#27 / pooza/shooby-do-bop#362 / pooza/dqdai-anniv#35）。⚠ **本体だけ pull すると CommandSource の 7 ソースだけ古い gem で動き続けます。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)