### PR TITLE
fix: Sentry へ送るイベントから資格情報を落とす (#1467)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 8443ae749e35a49a49751828f4e58c522c8d1eb8
+  revision: 430ad064e94c3e8cea53cd1d5d8b3b4b32a723dc
   branch: main
   specs:
-    ginseng-core (1.20.0)
+    ginseng-core (1.22.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/tomato_shrieker.rb
+++ b/app/lib/tomato_shrieker.rb
@@ -20,11 +20,19 @@ module TomatoShrieker
   def self.setup_sentry
     dsn = Config.instance['/sentry/dsn']
     return unless dsn
+    # ⚠⚠ **マスクを Sentry.init の外で用意する (#1467)。** 中で組み立てると、
+    # 失敗が下の rescue に落ちて「Sentry は初期化されないが警告だけ出る」形になり、
+    # **マスクが無いまま送る状態には決してしない**という意図が読めなくなる。
+    # ここで raise すれば Sentry ごと立ち上がらない ＝ fail closed。
+    scrubber = SentryScrubber.new
     Sentry.init do |config|
       config.dsn = dsn
       config.release = Package.version
       config.environment = Environment.type
       config.traces_sample_rate = Config.instance['/sentry/traces_sample_rate'] || 0
+      # ⚠ `send_default_pii` は既定 false のまま。問題は「自分で例外メッセージへ
+      # 埋めているぶん」なので、既定値では守れない。
+      config.before_send = proc {|event, _hint| scrubber.scrub(event)}
     end
   rescue => e
     warn "Sentry initialization skipped: #{e.message}"

--- a/app/lib/tomato_shrieker/sentry_scrubber.rb
+++ b/app/lib/tomato_shrieker/sentry_scrubber.rb
@@ -1,0 +1,78 @@
+module TomatoShrieker
+  # Sentry へ送るイベントから資格情報を落とす (#1467)。
+  #
+  # 🔴 **ログでは伏せている値が、例外イベントとしては素通りしていた。**
+  # `sentry-ruby` の `send_default_pii` は既定 false だが、守られるのは
+  # リクエストヘッダ等であって、**アプリが自分で例外メッセージへ埋めた値**は
+  # 対象外。tomato はまさにそれをやっている。
+  #
+  #   raise Ginseng::GatewayError, "Invalid feed #{id} (#{uri}) #{e.message}"
+  #
+  # ⚠⚠ **マスクの正本は `Ginseng::Logger`。** ここで同等品を書くと、対象の列が
+  # ログ側と 2 か所に分かれて必ずズレる。`/logger/mask_fields` /
+  # `/logger/mask_query_params` / `/logger/mask_url_paths` を唯一の正本に保つため、
+  # gem 側の `mask` / `mask_url` をそのまま呼ぶ（pooza/ginseng-core#580 で public
+  # になった）。
+  class SentryScrubber
+    include Package
+
+    # ⚠ **ここで logger を掴んでおく。** イベントごとに new すると、マスク設定の
+    # 読み出しがイベント送信時の文脈に移る。初期化時に解決しておけば、設定が
+    # 読めないときは Sentry ごと立ち上がらない（fail closed）。
+    def initialize
+      @logger = logger
+      # 設定が読めることをここで確かめる。⚠ 読めないまま before_send に入ると、
+      # 「マスク対象ゼロ ＝ 素通し」で送り続けることになる。
+      @logger.mask_url('https://example.com/?token=probe')
+    end
+
+    # ⚠ **必ず event を返すこと。** `before_send` が `Sentry::ErrorEvent` 以外を
+    # 返すとイベントは破棄される（sentry-ruby 6.6.2 の client.rb）。
+    def scrub(event)
+      scrub_exceptions(event)
+      event.message = mask(event.message) if event.message.is_a?(String)
+      event.transaction = mask(event.transaction) if event.transaction.is_a?(String)
+      event.extra = mask(event.extra)
+      event.tags = mask(event.tags)
+      event.contexts = mask(event.contexts)
+      event.user = mask(event.user)
+      scrub_breadcrumbs(event)
+      return event
+    rescue => e
+      # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。
+      # 素通しで送ると、伏せるはずだった値がそのまま外部サービスへ出る。
+      warn "Sentry event dropped (scrub failed): #{e.class}"
+      return nil
+    end
+
+    private
+
+    # 例外メッセージ本体。⚠ **ここが tomato でいちばん漏れる場所。**
+    # `SingleExceptionInterface#value` だけが writable。
+    def scrub_exceptions(event)
+      # ⚠ 局所変数へ受けてから回す。`event.exception` は Hash ではなく
+      # `Sentry::ExceptionInterface`（`values` は Array）なので、`each_value` は
+      # 生えていない。RuboCop の Style/HashEachMethods を誤爆させないため。
+      entries = event.exception&.values
+      return unless entries
+      entries.each do |entry|
+        entry.value = mask(entry.value) if entry.value.is_a?(String)
+      end
+    end
+
+    def scrub_breadcrumbs(event)
+      event.breadcrumbs&.buffer&.each do |crumb|
+        next unless crumb
+        crumb.message = mask(crumb.message) if crumb.message.is_a?(String)
+        crumb.data = mask(crumb.data) if crumb.data.is_a?(Hash)
+      end
+    end
+
+    # ⚠ `Ginseng::Logger#mask` は Hash / Array / String を再帰的に処理し、
+    # `mask_fields` のキーは**値ごと落とす**。String は `mask_url` を通る。
+    def mask(value)
+      return value unless value.is_a?(String) || value.is_a?(Hash) || value.is_a?(Array)
+      return @logger.mask(value)
+    end
+  end
+end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -39,6 +39,14 @@ logger:
     - password
     - secret
     - auth
+  # ⚠ URL の**パス**が資格情報になっている宛先 (pooza/ginseng-core#580)。
+  # モロヘイヤの webhook は POST /mulukhiya/webhook/{digest} で、digest を知って
+  # いれば誰でもそのアカウントで投稿できる。接頭辞の次の 1 セグメントを落とす。
+  #
+  # ⚠ ginseng-core の既定にも同じ値が入っているので、ここは「本アプリが何を
+  # 秘密とみなしているか」を明示するためのもの。既定に頼らず書いておく。
+  mask_url_paths:
+    - /mulukhiya/webhook/
 package:
   authors:
     - Tatsuya Koishi

--- a/test/sentry_scrubber.rb
+++ b/test/sentry_scrubber.rb
@@ -1,0 +1,94 @@
+module TomatoShrieker
+  # Sentry へ送るペイロードから資格情報が落ちていること (#1467)。
+  #
+  # ⚠⚠ **「マスク処理を呼んでいる」ではなく「出力に含まれていない」を見る。**
+  # 呼んでいるかどうかは、対象の列がズレていれば通ってしまう。
+  class SentryScrubberTest < TestCase
+    # モロヘイヤの webhook は POST /mulukhiya/webhook/{digest} で、**パスその
+    # ものが資格情報**。digest を知っていれば誰でもそのアカウントで投稿できる。
+    WEBHOOK_DIGEST = 'fa9c541e163ff35ac49e12dd5ad71dc4e27876a3a5514f46d074e9b6f190652d'.freeze
+    WEBHOOK_URL = "https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST}".freeze
+    FEED_TOKEN = 'SUPERSECRETTOKEN'.freeze
+    FEED_URL = "https://example.com/feed.xml?access_token=#{FEED_TOKEN}".freeze
+
+    def setup
+      @scrubber = SentryScrubber.new
+    end
+
+    def test_new
+      assert_kind_of(SentryScrubber, @scrubber)
+    end
+
+    # 🔴 tomato でいちばん漏れる経路。WebhookShrieker の失敗は
+    # Ginseng::GatewayError になり、メッセージに URI が丸ごと載る。
+    def test_scrub_exception_message
+      event = error_event(Ginseng::GatewayError.new("Bad response 404 (#{WEBHOOK_URL})"))
+
+      scrubbed = @scrubber.scrub(event)
+
+      assert_not_nil(scrubbed, 'イベントを落としてはいけない')
+      assert_not_include(payload(scrubbed), WEBHOOK_DIGEST)
+      assert_include(payload(scrubbed), '[FILTERED]')
+    end
+
+    # FeedSource#feedjira は URI を丸ごとメッセージへ埋める。認証付きフィードを
+    # 足した時点で、そのまま Sentry へ出る。
+    def test_scrub_exception_message_query_credentials
+      event = error_event(Ginseng::GatewayError.new("Invalid feed x (#{FEED_URL})"))
+
+      assert_not_include(payload(@scrubber.scrub(event)), FEED_TOKEN)
+    end
+
+    # extra / tags は自分で積む場所なので、mask_fields のキーごと落ちること。
+    def test_scrub_extra_and_tags
+      event = error_event(StandardError.new('boom'))
+      event.extra = {password: 'PLAINTEXT', url: WEBHOOK_URL, source: 'shooby'}
+      event.tags = {secret: 'PLAINTEXT'}
+
+      scrubbed = payload(@scrubber.scrub(event))
+
+      assert_not_include(scrubbed, 'PLAINTEXT')
+      assert_not_include(scrubbed, WEBHOOK_DIGEST)
+      assert_include(scrubbed, 'shooby', '無関係な値は残す')
+    end
+
+    # ⚠ 資格情報を含まない情報まで消してはいけない。消すと調査に使えなくなる。
+    def test_scrub_keeps_diagnostics
+      event = error_event(Ginseng::GatewayError.new('Invalid feed vjump-youtube (https://www.youtube.com/feeds/videos.xml?channel_id=UCTwO5UAGiB8AdFrsxhNKaRQ)'))
+
+      scrubbed = payload(@scrubber.scrub(event))
+
+      assert_include(scrubbed, 'vjump-youtube')
+      assert_include(scrubbed, 'UCTwO5UAGiB8AdFrsxhNKaRQ')
+    end
+
+    # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。素通しで送ると
+    # 伏せるはずだった値がそのまま外部サービスへ出る。
+    def test_scrub_drops_event_when_mask_fails
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+
+      assert_nil(@scrubber.scrub(event))
+    end
+
+    private
+
+    def error_event(error)
+      client = Sentry::Client.new(sentry_configuration)
+      return client.event_from_exception(error)
+    end
+
+    def sentry_configuration
+      config = Sentry::Configuration.new
+      config.dsn = 'https://publickey@example.com/1'
+      config.environment = 'test'
+      return config
+    end
+
+    # ⚠ **実際に送られる形（シリアライズ後）で見る。** アクセサ越しに 1 つずつ
+    # 確かめると、見落とした欄がそのまま外へ出る。
+    def payload(event)
+      return event.to_json_compatible.to_json
+    end
+  end
+end


### PR DESCRIPTION
closes #1467

## 調べたら、Sentry より前にログで漏れていた

🔴 **本番（oscura）で、成功した POST のたびに webhook の digest が平文で syslog に出ていました。**

```
{"method":"POST","url":"https://precure.ml/mulukhiya/webhook/fa9c541e…","status":200,"seconds":0.934}
```

⚠ **この digest を知っていれば誰でもそのアカウントで投稿できます。**当日ログだけで 22 行。さらに例外メッセージ経由でも出ていました。

```
{"source":"precure-youtube","error":{"message":"Invalid feed precure-youtube (https://www.youtube.com/…) Bad response 500"}
```

原因は `Ginseng::Logger` 側で、**tomato で回避せず上流を直しました**（[workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) の分界）。

| | 内容 |
| --- | --- |
| [ginseng-core#580](https://github.com/pooza/ginseng-core/issues/580) | `mask_url` が**クエリしか見ていない**。パスが資格情報の URL は素通り → `/logger/mask_url_paths` を新設（**1.21.0**） |
| [ginseng-core#582](https://github.com/pooza/ginseng-core/issues/582) | `URL_PATTERN` に `\A` の錨があり、**例外メッセージに埋まった URL は `mask_url` に届かない** → `mask` が文字列中の URL を 1 つずつ通す（**1.22.0**） |

⚠ **#582 が入るまで、#580 は「呼ばれないので効かない」状態でした。**

## 本 PR の中身

**`SentryScrubber`** を追加し、`before_send` から通します。

- ⚠⚠ **マスクの正本は `Ginseng::Masking`。**同等品を書くと対象の列が 2 か所に分かれて必ずズレるので、gem 側の `mask` / `mask_url` をそのまま呼びます（#580 / #582 で public 化）
- ⚠ **`scrubber` を `Sentry.init` の外で用意します。**中で組み立てると失敗が `rescue` に落ち、「Sentry は動くがマスクは無い」形になりえます。外で raise すれば **Sentry ごと立ち上がらない ＝ fail closed**
- 🔴 **scrub に失敗したイベントは送りません**（`before_send` が nil を返す）。素通しで送ると、伏せるはずだった値が外部サービスへ出ます
- ⚠ `send_default_pii` は **既定 false のまま**。問題は「自分で例外メッセージへ埋めているぶん」なので、既定値では守れません
- `config/application.yaml` に `logger.mask_url_paths` を明示（gem の既定にも同じ値がありますが、**本アプリが何を秘密とみなしているかを設定に残す**ため）

## 検証

**216 tests / 0 failures / 0 errors**、RuboCop 無指摘（87 files）。

⚠ **「マスク処理を呼んでいる」ではなく「出力に含まれていない」を見る正テスト**です。`event.to_json_compatible.to_json` ＝ **実際に送られる形**で確かめています（アクセサ越しに 1 つずつ見ると、見落とした欄がそのまま外へ出るため）。

**実機での end-to-end 確認**:

```
initialized=true
before_send set=true
send_default_pii=false
digest leaked? false
"value":"Bad response 404 (https://precure.ml/mulukhiya/webhook/[FILTERED]) (Ginseng::GatewayError)"
```

⚠ **fix を外すと新規 3 件が赤くなることを確認済み**（`scrub_exception_message` / `scrub_exception_message_query_credentials` / `scrub_extra_and_tags`）。

## ⚠ 残っている露出（別 Issue）

本 PR は **Sentry とログ**を塞ぎますが、**`/status.json` の `last_error` は素のまま**です。しかも本番の `monitor.bind` は `0.0.0.0` でホストファイアウォールも無く、**LAN / VPN の誰からでも読めます** → **#1531**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)