### PR TITLE
security: 例外メッセージの資格情報を落とし、保護行の error_message を期限で消す (#1511)

### DIFF
--- a/app/lib/tomato_shrieker/model/source_run_log.rb
+++ b/app/lib/tomato_shrieker/model/source_run_log.rb
@@ -104,9 +104,29 @@ module TomatoShrieker
 
     def self.prune(retention_days)
       cutoff = Time.now - (retention_days * 86_400)
+      count = where(Sequel.lit('executed_at < ?', cutoff))
+        .exclude(id: last_delivered_ids).exclude(id: first_run_ids)
+        .exclude(id: last_attempted_ids).delete
+      redact_expired(cutoff)
+      return count
+    end
+
+    # 🔴 **retention を過ぎても残す保護行から error_message を落とす (#1511)。**
+    #
+    # 保護行は 3 系統に増え、**ソースあたり最大 3 行が retention_days を超えて
+    # 無期限に残る**ようになった。⚠ とくに `last_attempted_ids` が守る行は
+    # 「直近の配信試行」＝ `partial` / `error` で `error_message` を持つ可能性が
+    # 最も高い。`/monitor/retention_days` が担保していた「例外メッセージは
+    # N 日で消える」という上限が、保護行だけ外れていた。
+    #
+    # ⚠ **削除の後に呼ぶこと。** 保護されていない期限切れ行は先に消えているので、
+    # ここで残っている期限切れ行は保護行だけになる。
+    #
+    # ⚠ 判定に使うのは `executed_at` / `attempted_count` / `delivered_count` だけ
+    # なので、`error_message` を落としても保護の意味は失われない。
+    def self.redact_expired(cutoff)
       return where(Sequel.lit('executed_at < ?', cutoff))
-          .exclude(id: last_delivered_ids).exclude(id: first_run_ids)
-          .exclude(id: last_attempted_ids).delete
+          .exclude(error_message: nil).update(error_message: nil)
     end
 
     # 「最後に配信できた時刻」の根拠行はソースごとに 1 行だけ prune から守る。

--- a/app/lib/tomato_shrieker/package.rb
+++ b/app/lib/tomato_shrieker/package.rb
@@ -61,7 +61,35 @@ module TomatoShrieker
     # 「エラーを報告しようとして同じ例外を踏む」を避けるため、rescue 節の中でも通す。
     def self.error_message(error)
       return nil unless error
-      return "#{error.class}: #{error.message}".to_utf8
+      return mask_credentials("#{error.class}: #{error.message}".to_utf8)
+    end
+
+    # 🔴 **例外メッセージに埋まった資格情報を落とす (#1511)。**
+    #
+    # アプリは URL を丸ごとメッセージへ埋める。
+    #
+    #   raise Ginseng::GatewayError, "Invalid feed #{id} (#{uri}) #{e.message}"
+    #
+    # ここを通った文字列は **`source_run_log.error_message` に保存され**、
+    # `/status.json` と `/healthz/source` からそのまま読める。⚠ 本番の
+    # `monitor.bind` は `0.0.0.0` なので、LAN / VPN の誰からでも見える (#1531)。
+    #
+    # ⚠⚠ **`to_utf8` の後に通すこと。** 不正なバイト列のまま gsub すると
+    # ArgumentError になり、**マスクごと素通りする** (#518 で踏んだ型)。
+    #
+    # ⚠ マスクの正本は `Ginseng::Masking`。ここで同等品を書かない (#1467)。
+    def self.mask_credentials(message)
+      return Logger.new.mask_urls_in(message)
+    rescue => e
+      # 🔴 **fail closed。** マスクを通せなかった文字列は出さない。素通しにすると
+      # 伏せるはずだった値が run_log と監視エンドポイントへ残る。
+      return "#{error_class_of(message)} (masking failed: #{e.class})"
+    end
+
+    # マスクに失敗したとき、せめて例外クラス名だけは残す。⚠ 診断の手掛かりが
+    # ゼロになると「マスクが壊れている」ことにも気付けない。
+    def self.error_class_of(message)
+      return message.to_s.split(':', 2).first.to_s
     end
 
     def self.included(base)

--- a/test/package.rb
+++ b/test/package.rb
@@ -1,0 +1,70 @@
+module TomatoShrieker
+  class PackageTest < TestCase
+    # 🔴 例外メッセージに埋まった資格情報が落ちること (#1511)。
+    #
+    # ⚠ Package.error_message は **source_run_log.error_message の唯一の入口**で、
+    # かつ /healthz/source の 503 本文にも使われる。ここを通った文字列は
+    # /status.json からそのまま読める。本番の monitor.bind は 0.0.0.0 なので
+    # LAN / VPN の誰からでも見える (#1531)。
+    WEBHOOK_DIGEST = 'fa9c541e163ff35ac49e12dd5ad71dc4e27876a3a5514f46d074e9b6f190652d'.freeze
+
+    def test_error_message
+      assert_nil(Package.error_message(nil))
+      assert_equal(
+        'Ginseng::GatewayError: Bad response 404',
+        Package.error_message(Ginseng::GatewayError.new('Bad response 404')),
+      )
+    end
+
+    # WebhookShrieker の失敗はこの形になる。digest を知っていれば誰でも投稿できる。
+    def test_error_message_masks_webhook_digest
+      error = Ginseng::GatewayError.new(
+        "Bad response 404 (https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST})",
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, WEBHOOK_DIGEST)
+      assert_include(message, '[FILTERED]')
+      assert_include(message, 'Bad response 404', '診断に要る情報は残す')
+    end
+
+    # FeedSource#feedjira は URI を丸ごとメッセージへ埋める。認証付きフィードを
+    # 足した時点で、そのまま run_log へ保存される。
+    def test_error_message_masks_feed_token
+      error = Ginseng::GatewayError.new(
+        'Invalid feed x (https://example.com/feed.xml?access_token=TOKENVALUE) Bad response 500',
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, 'TOKENVALUE')
+      assert_include(message, 'Bad response 500')
+    end
+
+    # ⚠ 資格情報を含まない URL は残すこと。消すとどのフィードが壊れたのか判らない。
+    def test_error_message_keeps_harmless_url
+      error = Ginseng::GatewayError.new(
+        'Invalid feed vjump-youtube (https://www.youtube.com/feeds/videos.xml?channel_id=UCTwO5UAGiB8AdFrsxhNKaRQ) Bad response 404',
+      )
+
+      message = Package.error_message(error)
+
+      assert_include(message, 'UCTwO5UAGiB8AdFrsxhNKaRQ')
+      assert_include(message, 'vjump-youtube')
+    end
+
+    # ⚠ 不正なバイト列でもマスクごと素通りしないこと (#518 / #1469 の族)。
+    # to_utf8 の後にマスクを通しているかを見る。
+    def test_error_message_masks_broken_bytes
+      error = Ginseng::GatewayError.new(
+        "\xE3\x81 (https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST})",
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, WEBHOOK_DIGEST)
+      assert_true(message.valid_encoding?)
+    end
+  end
+end

--- a/test/source_run_log.rb
+++ b/test/source_run_log.rb
@@ -107,6 +107,42 @@ module TomatoShrieker
       assert_not_nil(SourceRunLog.last_delivered_at(SOURCE_ID))
     end
 
+    # 🔴 #1511: 保護行は retention_days を超えて無期限に残るので、そこに
+    # error_message が乗ったままだと「例外メッセージは N 日で消える」という
+    # 保持上限が保護行だけ外れる。⚠ 判定に使うのは executed_at /
+    # attempted_count / delivered_count だけなので、落としても保護は壊れない。
+    def test_prune_redacts_error_message_of_protected_rows
+      SourceRunLog.create(
+        source_id: SOURCE_ID, executed_at: Time.now - (20 * 86_400),
+        status: SourceRunLog::STATUS_PARTIAL, duration_ms: 10,
+        attempted_count: 2, delivered_count: 1,
+        error_message: 'Ginseng::GatewayError: Invalid feed x (https://example.com/f?access_token=TOKENVALUE)'
+      )
+      SourceRunLog.prune(14)
+      remain = SourceRunLog.where(source_id: SOURCE_ID).all
+
+      assert_equal(1, remain.size, '保護行そのものは残る')
+      assert_nil(remain.first.error_message)
+      assert_true(SourceRunLog.undelivered?(SOURCE_ID), '取りこぼしの判定は生きている')
+    end
+
+    # ⚠ 期限内の行の error_message は消さないこと。消すと直近の失敗理由が
+    # 読めなくなる。
+    def test_prune_keeps_error_message_within_retention
+      SourceRunLog.create(
+        source_id: SOURCE_ID, executed_at: Time.now - 3600,
+        status: SourceRunLog::STATUS_ERROR, duration_ms: 10,
+        attempted_count: 1, delivered_count: 0,
+        error_message: 'Ginseng::GatewayError: Bad response 404'
+      )
+      SourceRunLog.prune(14)
+
+      assert_equal(
+        'Ginseng::GatewayError: Bad response 404',
+        SourceRunLog.where(source_id: SOURCE_ID).first.error_message,
+      )
+    end
+
     # 🔴 #1504: 取りこぼしの根拠行を刈ると、赤くなったソースが retention_days の
     # 経過だけで黙って緑に戻る。「次に配信できたときだけ解除する」が壊れる。
     def test_prune_keeps_last_attempted_row


### PR DESCRIPTION
closes #1511

## 2 段で塞ぐ

Issue は「保護行の `error_message` を NULL 化する」でしたが、**書く前に落とすほうが先**なので両方入れました。

### 1. `Package.error_message` でマスクする

⚠ **ここは `source_run_log.error_message` の唯一の入口**で、かつ `/healthz/source` の 503 本文にも使われます。書く前に落とせば、**保持期間の話とは独立して効きます**。

```ruby
# 前
'Ginseng::GatewayError: Invalid feed x (https://example.com/f.xml?access_token=TOKENVALUE) Bad response 500'
# 後
'Ginseng::GatewayError: Invalid feed x (https://example.com/f.xml?access_token=[FILTERED]) Bad response 500'
```

- ⚠ **マスクの正本は `Ginseng::Masking`。**同等品は書きません（#1467 と同じ方針）
- ⚠⚠ **`to_utf8` の後に通します。**不正なバイト列のまま `gsub` すると `ArgumentError` になり、**マスクごと素通りします**（#518 で踏んだ型）。テストで固定しました
- 🔴 **マスクに失敗したら例外クラス名だけ残して本文を捨てます**（fail closed）。素通しにすると、伏せるはずだった値が run_log と監視エンドポイントに残ります
- ⚠ **資格情報を含まない URL は残します。**消すとどのフィードが壊れたのか判らなくなるので、`channel_id` などはそのままです

### 2. `prune` が保護行の `error_message` を NULL 化する

保護行は 3 系統（`last_delivered_ids` / `first_run_ids` / `last_attempted_ids`）で、**ソースあたり最大 3 行が `retention_days` を超えて無期限に残ります**。⚠ とくに `last_attempted_ids` が守る行は「直近の配信試行」＝ `partial` / `error` で `error_message` を持つ可能性が最も高い行です。

⚠ 判定に使うのは `executed_at` / `attempted_count` / `delivered_count` だけなので、**落としても保護の意味は失われません**（テストで `undelivered?` が生きていることを確認）。

## 検証

**223 tests / 0 failures / 0 errors**、RuboCop 無指摘（55 files）。

⚠ **fix を外すと新規 4 件が赤くなることを確認済み。**⚠ 実際、**一度この確認に助けられました** — 復元したつもりの `redact_expired(cutoff)` の呼び出しが（autocorrect でインデントが変わっていたため）当たっておらず、テストが落ちて気付きました。

## ⚠ 既存行について

本 PR は**これから書かれる行**をマスクします。⚠ **本番には URL を含む `error_message` が 1,112 行あります**が、

- **webhook の digest を含む行は 0 件**（Matrix 障害の解消後、webhook の恒久失敗が起きていないため）＝ 実際に伏せたい値は現状入っていない
- 期限切れの行は**次の prune で全部 NULL になります**（`redact_expired` は保護行に限らず期限切れ行すべてを対象にします）
- 期限内（14 日）の行は、そのまま aging out します

⚠ **backfill の migration は入れていません。**実際に伏せたい値が入っていないため、リスクに見合わないと判断しました。

## ⚠ 残っている露出

本 PR で `error_message` の中身は安全になりますが、**`/status.json` に認証が無く、本番の `monitor.bind` は `0.0.0.0`（ufw 無効・nft policy accept）**という露出そのものは残ります → **#1531**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)