### PR TITLE
fix: Config#load を「読み切ってから 1 回で差し替える」形にする (#1530)

### DIFF
--- a/app/lib/tomato_shrieker/config.rb
+++ b/app/lib/tomato_shrieker/config.rb
@@ -2,17 +2,38 @@ module TomatoShrieker
   class Config < Ginseng::Config
     include Package
 
+    # 🔴 **ファイルを全部読み切ってから、self へは 1 回だけ書く (#1530)。**
+    #
+    # 以前は `self['/sources']` へ 1 件ずつ push していた。2 つの穴があった。
+    #
+    # 1. **途中で失敗すると戻せない。** 1 ファイルが `Psych::SyntaxError` を
+    #    上げると、`/sources` は**途中まで積まれた状態で残る**。⚠ ソース定義を
+    #    手で 1 文字打ち間違えただけで、稼働中のソース一覧が壊れた
+    # 2. **途中経過が監視から見える。** push している間 `/sources` は短いまま。
+    #    ⚠ `/status.json` は全ソースを舐めるので約 900ms かかり（#1472）、
+    #    この窓に重なると**ソースが欠けて見える**。`/healthz/source/:id` は
+    #    `Source.create(id)` が見つからず **404** を返す。Kuma に偽の 404 / 503 が出る
+    #
+    # ⚠ **`source_entries` を `super` より先に呼ぶこと。** ファイル I/O を先に
+    # 済ませておけば、`super` の `update` と下の代入の間に I/O が挟まらず、
+    # 窓はマイクロ秒まで縮む。壊れた YAML があれば `self` を一切変更しないまま
+    # raise するので、呼び出し側は前の内容のまま走り続ける。
+    #
+    # ⚠ `+` で新しい配列を作る。`super` が返す配列は `@raw` の実体そのものなので、
+    # そこへ push すると load のたびに積み増さる（ginseng-core#491）。
     def load
+      entries = source_entries
       super
-      # super が返す配列は @raw の実体そのもの。直に push すると load を呼ぶたびに
-      # ソース定義が積み増され、同じソースが多重登録される。複製してから積む。
-      self['/sources'] = self['/sources'].dup
-      suffixes.each do |suffix|
-        Dir.glob(File.join(Environment.dir, 'config/sources', "*#{suffix}")).each do |f|
-          key = File.basename(f, suffix)
+      self['/sources'] = self['/sources'] + entries
+    end
+
+    # `config/sources/*.yaml` を読んで配列にする。⚠ self には触らない。
+    def source_entries
+      return suffixes.flat_map do |suffix|
+        Dir.glob(File.join(Environment.dir, 'config/sources', "*#{suffix}")).map do |f|
           values = YAML.load_file(f)
-          values['id'] ||= key
-          self['/sources'].push(values)
+          values['id'] ||= File.basename(f, suffix)
+          values
         end
       end
     end

--- a/test/config.rb
+++ b/test/config.rb
@@ -1,11 +1,75 @@
 module TomatoShrieker
-  class ConfigText < TestCase
-    def load
-      config.load
+  class ConfigTest < TestCase
+    # ⚠ 実在のソースと衝突しない接頭辞。後始末に失敗しても見分けがつくようにする。
+    PREFIX = '__test_config_atomic__'.freeze
+
+    def teardown
+      cleanup
+      super
     end
 
     def test_secure_dump
       assert_kind_of(Array, config.secure_dump)
+    end
+
+    # #1530: reload の途中経過が外から見えないこと。
+    #
+    # 🔴 以前は `self['/sources']` へ 1 件ずつ push していたので、push の間だけ
+    # 一覧が短かった。⚠ `/status.json` は全ソースを舐めるので約 900ms かかり
+    # (#1472)、この窓に重なると**ソースが欠けて見える**。`/healthz/source/:id` は
+    # 404 を返し、Kuma に偽の 404 / 503 が出る。
+    def test_load_never_exposes_partial_sources
+      write_sources(5)
+      config.reload
+      expected = config['/sources'].size
+      observed = []
+      reader = Thread.new do
+        observed.push(config['/sources'].size) while Thread.current[:run] != false
+      end
+      reader[:run] = true
+      10.times {config.reload}
+      reader[:run] = false
+      reader.join(5)
+
+      assert_operator(observed.size, :>, 0, '読み手が 1 度も観測できていない')
+      assert_equal([expected], observed.uniq, "reload の途中経過が見えている: #{observed.uniq.sort}")
+    end
+
+    # 🔴 #1530: 壊れた YAML があっても、それまでの内容を壊さないこと。
+    #
+    # 以前は 3 件目で raise すると 2 件目まで積まれた状態で残った。⚠ ソース定義を
+    # 手で 1 文字打ち間違えただけで、稼働中のソース一覧が壊れた。
+    def test_load_keeps_previous_sources_when_yaml_is_broken
+      write_sources(3)
+      config.reload
+      before = config['/sources'].size
+
+      File.write(source_path('broken'), "source:\n  feed: [unclosed\n")
+
+      assert_raise_kind_of(StandardError) {config.reload}
+      assert_equal(before, config['/sources'].size, '壊れた YAML で一覧が欠けている')
+    end
+
+    private
+
+    def write_sources(count)
+      count.times do |i|
+        File.write(source_path(i), {
+          'source' => {'text' => "test #{i}"},
+          'schedule' => {'cron' => '0 0 * * *'},
+          'dest' => {'tags' => ['test']},
+        }.to_yaml)
+      end
+    end
+
+    def source_path(key)
+      return File.join(Environment.dir, 'config/sources', "#{PREFIX}#{key}.yaml")
+    end
+
+    def cleanup
+      Dir.glob(File.join(Environment.dir, 'config/sources', "#{PREFIX}*")).each do |f|
+        File.delete(f)
+      end
     end
   end
 end


### PR DESCRIPTION
closes #1530

`config/sources/*.yaml` を `self['/sources']` へ **1 件ずつ push** していたため、穴が 2 つありました。

## 🔴 1. 途中で失敗すると戻せない

1 ファイルが `Psych::SyntaxError` を上げると、**`/sources` は途中まで積まれた状態で残ります**。`Config` は `Ginseng::Config < Hash` ＝ シングルトンの Hash 本体を in-place で更新しているので、巻き戻す手段がありません。

⚠ **ソース定義を手で 1 文字打ち間違えただけで、稼働中のソース一覧が壊れます。**

## ⚠ 2. 途中経過が監視から見える

push している間、`/sources` は短いままです。

- `/status.json` は全ソースを舐めるので **1 リクエスト約 900ms**（#1472）＝窓に重なりやすい
- `/healthz/source/:id` は `Source.create(id)` が見つからず **404** を返す

🔴 **Kuma に偽の 404 / 503 が出ます。**

## 変更

```ruby
def load
  entries = source_entries   # ⚠ ファイル I/O を先に全部済ませる
  super
  self['/sources'] = self['/sources'] + entries   # 代入 1 回
end
```

- **壊れた YAML があれば `self` を一切変更しないまま raise** ＝ 呼び出し側は前の内容のまま走り続ける
- `super` の `update` と代入の間に **I/O が挟まらない**ので、途中経過が見える窓はマイクロ秒まで縮む
- ⚠ **`+` で新しい配列を作ります**（`dup` + `push` をやめた）。`super` が返す配列は `@raw` の実体そのものなので、そこへ push すると load のたびに積み増さります（[ginseng-core#491](https://github.com/pooza/ginseng-core/issues/491)）

## 検証

**225 tests / 0 failures / 0 errors**、RuboCop 無指摘（88 files）。

⚠ **fix を外すと新規 2 件が赤くなることを確認済み。**

- `test_load_never_exposes_partial_sources` — 別スレッドで `config['/sources'].size` を回しながら 10 回 reload し、**観測値が一度も欠けない**ことを見る
- `test_load_keeps_previous_sources_when_yaml_is_broken` — 壊れた YAML を置いて reload。**例外は上がるが件数は前のまま**

## ⚠ 仕様として維持していること

`Ginseng::Config#load` は `next if @raw.key?(key)` で**一度読んだファイルを二度と読まない**ので、`application.yaml` / `local.yaml` は reload しても更新されません。**本 PR でここは変えていません**（`/monitor/bind` のようなキーを稼働中に差し替えられても困るため）。#1459 の設計でも同じ前提を置いています。

## 余談

`test/config.rb` のクラス名が `ConfigText`（`ConfigTest` の綴り間違い）だったので直しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)