### PR TITLE
refactor: リリース前レビュー由来の小物を片付ける (#1490, #1512, #1513)

### DIFF
--- a/app/lib/tomato_shrieker/cli/source_command.rb
+++ b/app/lib/tomato_shrieker/cli/source_command.rb
@@ -132,8 +132,7 @@ module TomatoShrieker
       SilenceAck.acknowledge(id)
       say "#{id} を確認済みにしました。"
       # ⚠ 「今後も問題ない」の保証ではないことを操作のたびに示す。
-      days = source.monitor_silence_tolerance_seconds / 86_400
-      say "  次に silence_tolerance (#{days}日) を超えたら、再び警告します。"
+      say "  次に silence_tolerance (#{tolerance_label(source)}) を超えたら、再び警告します。"
     end
 
     desc 'validate [ID]', 'ソース定義を JSON Schema で検証（ID 省略時は全件）'
@@ -162,6 +161,20 @@ module TomatoShrieker
     end
 
     private
+
+    # silence_tolerance を人が読める長さで返す (#1513)。
+    #
+    # ⚠ **整数除算で「0日」と出してはいけない。** スキーマは `12h` / `30m` を許す
+    # ので（`^((\d+(\.\d+)?[smhdwMy])+|\d+(\.\d+)?)$`）、日未満を設定した
+    # ソースでは「次に silence_tolerance (0日) を超えたら」と出ていた。
+    # ⚠ #1496 の「9 月上旬に 7d → 3d へ締める」運用で日未満を入れたら踏む。
+    def tolerance_label(source)
+      seconds = source.monitor_silence_tolerance_seconds
+      return "#{seconds / 86_400}日" if (seconds % 86_400).zero?
+      return "#{seconds / 3_600}時間" if (seconds % 3_600).zero?
+      return "#{seconds / 60}分" if (seconds % 60).zero?
+      return "#{seconds}秒"
+    end
 
     def find_source!(id, klass = nil)
       sources = klass ? klass.all : Source.all

--- a/app/lib/tomato_shrieker/delivery_stats.rb
+++ b/app/lib/tomato_shrieker/delivery_stats.rb
@@ -23,24 +23,14 @@ module TomatoShrieker
     end
 
     def record_error(shrieker, error)
-      @mutex.synchronize do
-        @attempted_count += 1
-        @shrieker_errors[shrieker.class.to_s] += 1
-        @errors.push(error)
-      end
-      return nil
+      return record_attempted_failure(shrieker.class, error)
     end
 
     # 設定されているのに Shrieker を組み立てられなかった宛先 (#1504)。
     # アクセサが例外を握って nil を返すため、この宛先は shriekers から消える。
     # attempted に載せないと「宛先ゼロで完走した run」＝緑になる。
     def record_unavailable(kind, error)
-      @mutex.synchronize do
-        @attempted_count += 1
-        @shrieker_errors[kind.to_s] += 1
-        @errors.push(error)
-      end
-      return nil
+      return record_attempted_failure(kind, error)
     end
 
     # 配信まで到達せずに落ちた失敗。Shrieker が特定できない経路（FeedSource#fetch の
@@ -63,6 +53,25 @@ module TomatoShrieker
 
     def shrieker_errors
       return @mutex.synchronize {@shrieker_errors.dup}
+    end
+
+    # 「宛先に触ったが届かなかった」失敗の共通処理 (#1490)。
+    #
+    # ⚠⚠ **record_failure と一本化してはいけない。** 見た目は似ているが
+    # **`@attempted_count` と `@failure_count` で別の数を数えている**。
+    # `record_failure` は宛先に一度も触れていない失敗なので attempted に載せず、
+    # 載せると `delivered < attempted` が成立して `undelivered?`（#1504）が嘘で
+    # 立つ。⚠ しかも解除は「次に全宛先へ届く run」だけなので、疎なソースは
+    # 数週間 503 に貼り付く。
+    #
+    # ⚠ `kind` は Class でも文字列でもよい（`to_s` で同じ値になる）。
+    def record_attempted_failure(kind, error)
+      @mutex.synchronize do
+        @attempted_count += 1
+        @shrieker_errors[kind.to_s] += 1
+        @errors.push(error)
+      end
+      return nil
     end
 
     def error_count

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module TomatoShrieker
@@ -89,7 +91,11 @@ module TomatoShrieker
 
     # #1470: 配信できていないこと自体を出す
     def silent_body(source)
-      body = "silent: true\n"
+      # ⚠ `+` を付けて可変にする (#1512)。式展開の無いリテラルは将来 frozen に
+      # なるので、`<<` すると FrozenError で healthz_source の rescue に落ち、
+      # **503 の本文が診断情報を丸ごと失う**（ステータスは 503 のままなので
+      # Kuma は気づかない）。
+      body = +"silent: true\n"
       body << "last_delivered_at: #{source.last_delivered_at&.iso8601}\n"
       body << "silence_tolerance_seconds: #{source.monitor_silence_tolerance_seconds}\n"
       body << "noop_streak: #{SourceRunLog.noop_streak(source.id)}\n"
@@ -102,7 +108,8 @@ module TomatoShrieker
     # #1504: 「いつ・何件のうち何件が届かなかったか」を運用者に見せる。
     # ⚠ 宛先の識別子は持たないので「どの宛先か」は出せない。設定を見て切り分ける。
     def undelivered_body(log)
-      body = "undelivered: true\n"
+      # ⚠ 式展開の無いリテラルなので `+` で可変にする (#1512)。上の silent_body 参照。
+      body = +"undelivered: true\n"
       body << "last_attempted_at: #{log.executed_at.iso8601}\n"
       body << "attempted_count: #{log.attempted_count}\n"
       body << "delivered_count: #{log.delivered_count}\n"

--- a/app/lib/tomato_shrieker/template.rb
+++ b/app/lib/tomato_shrieker/template.rb
@@ -5,6 +5,11 @@ module TomatoShrieker
     # Source#templates は Template をインスタンスに memo 化するので、複製しないと
     # Parallel.each の各スレッドが同じ params を上書きし合う (#1474)。
     # @erb / @path は読み取り専用なので共有したままでよい。
+    #
+    # ⚠ **@params の複製は 1 段（浅コピー）** (#1490)。`Ginseng::Template#[]=` が
+    # `value.is_a?(Hash) ? value.deep_symbolize_keys : value` で**スロットごと
+    # 差し替える**前提に乗っている。⚠ **Hash 以外の可変値（Array 等）を params に
+    # 入れると共有に戻る**ので、そのときは別途複製が要る。
     def initialize_copy(original)
       super
       @params = original.params.dup

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -24,12 +24,18 @@ anyOf:
   - properties:
       dest:
         anyOf:
-          - required: [hooks]
-          - required: [mastodon]
-          - required: [misskey]
-          - required: [line]
-          - required: [piefed]
-          - required: [nostr]
+          - required:
+              - hooks
+          - required:
+              - mastodon
+          - required:
+              - misskey
+          - required:
+              - line
+          - required:
+              - piefed
+          - required:
+              - nostr
 properties:
   disable:
     type: boolean

--- a/test/source_command.rb
+++ b/test/source_command.rb
@@ -1,0 +1,33 @@
+module TomatoShrieker
+  class SourceCommandTest < TestCase
+    def setup
+      @command = SourceCommand.new
+    end
+
+    # #1513: silence_tolerance の表示が整数除算で「0日」にならないこと。
+    #
+    # ⚠ スキーマは `12h` / `30m` を許すので (`^((\d+(\.\d+)?[smhdwMy])+|\d+(\.\d+)?)$`)、
+    # 日未満のソースでは「次に silence_tolerance (0日) を超えたら」と出ていた。
+    # ⚠ #1496 の「9 月上旬に 7d → 3d へ締める」運用で日未満を入れたら踏む。
+    def test_tolerance_label
+      {
+        7_776_000 => '90日',
+        259_200 => '3日',
+        129_600 => '36時間',
+        43_200 => '12時間',
+        1_800 => '30分',
+        45 => '45秒',
+      }.each do |seconds, expected|
+        assert_equal(expected, @command.send(:tolerance_label, stub_source(seconds)))
+      end
+    end
+
+    private
+
+    def stub_source(seconds)
+      source = Object.new
+      source.define_singleton_method(:monitor_silence_tolerance_seconds) {seconds}
+      return source
+    end
+  end
+end


### PR DESCRIPTION
closes #1490
closes #1512
closes #1513

いずれも 4.5.0 / 4.6.0 のリリース前レビュー由来（🟢）。

## ⚠⚠ #1490 の 1 件目は、issue の提案どおりに直すとバグになります

issue は「`record_failure` が `record_error` のほぼ完全な複製で、差分は `shrieker.class.to_s` か `kind.to_s` かの 1 行だけ」としていますが、**事実と違います**。

| | 数えるもの |
| --- | --- |
| `record_error` | **`@attempted_count`** |
| `record_unavailable` | **`@attempted_count`** |
| `record_failure` | **`@failure_count`**（attempted には載せない） |

🔴 **提案どおり `record_error` を `record_failure` へ委譲すると、`delivered < attempted` が成立しなくなり `undelivered?`（#1504）の土台が壊れます。**`record_failure` 自身のコメントが「attempted_count には載せない」とわざわざ書いている通りです。

実際に試すと**既存テスト 4 件が赤くなりました**。

```
Failure: test_record_error(TomatoShrieker::DeliveryStatsTest)
Failure: test_record_error_with_stats(TomatoShrieker::SourceRunLogTest)
Failure: test_finalize_run_log_partial_keeps_errors(TomatoShrieker::SourceTest)
Failure: test_shriek_collects_delivery_errors(TomatoShrieker::SourceTest)
```

⚠ **本当の重複は `record_error` と `record_unavailable`** なので、そちらを `record_attempted_failure` へ寄せました。Mutex 区間は 3 → 2 に減り、`record_failure` は独立したまま残ります。**なぜ一本化してはいけないか**をメソッドのコメントに書いてあります。

## #1512 503 本文が凍結予定のリテラルを破壊的更新している

`silent_body` / `undelivered_body` が式展開の無いリテラルに `<<` していました。frozen が既定になると `FrozenError` で `healthz_source` の rescue に落ち、**503 の本文が診断情報を丸ごと失います**。⚠ **ステータスは 503 のままなので Kuma は気づきません。**

`+"..."` に変えたうえで、**`# frozen_string_literal: true` を付けていま壊れないことを担保**しました。⚠ `rake test` に出ていた警告も 0 件になります（他の警告が埋もれなくなる）。

## #1513 `source ack` の日数表示が「0日」になる

スキーマは `12h` / `30m` を許すので、日未満のソースでこう出ていました。

```
次に silence_tolerance (0日) を超えたら、再び警告します。
```

`tolerance_label` を切り出して丸めます。

| 秒 | 表示 |
| --- | --- |
| 7,776,000 | 90日 |
| 129,600 | **36時間** |
| 1,800 | **30分** |
| 45 | **45秒** |

⚠ 本番は現在すべて日単位なので実害ゼロですが、**#1496 の「9 月上旬に 7d → 3d へ締める」運用で日未満を入れたら踏みます。**

## #1490 のその他

- **schema の書式統一** — `config/schema/source.yaml` の `required: [hooks]` だけフロースタイルだったのをブロックスタイルへ
- **`Template#initialize_copy` に注記** — `@params` の複製が 1 段であること、⚠ **Array のような Hash 以外の可変値を入れると共有に戻る**ことを書き足し
- ✅ **`logger.warn` がマスクを素通りする件は上流で解消済み**（`l.method(:warn).owner` が `Ginseng::Logger` になっている）。対応不要でした
- ⏭ **`test_dest_count_does_not_instantiate_shriekers` は #1468 へ**（issue 本文どおり webmock と合わせて直すのが自然。#1468 は 4.9.0）

## 検証

**226 tests / 0 failures / 0 errors**、RuboCop 無指摘（89 files）。⚠ **#1513 の新規テストは fix を外すと赤くなることを確認済み。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)