### PR TITLE
feat: /status.json に Ruby ランタイム情報を含める (#1471)

### DIFF
--- a/app/lib/tomato_shrieker/environment.rb
+++ b/app/lib/tomato_shrieker/environment.rb
@@ -34,6 +34,41 @@ module TomatoShrieker
       return type == 'production'
     end
 
+    # ランタイムの能力欠落を可視化する (#1471)。
+    #
+    # 🔴 **YJIT は Rust の無い環境ではビルド時に黙って外れる。** エラーにならない
+    # まま「YJIT 抜きの Ruby」が完成し、バイトコード実行が 24〜25% 遅いサーバーが
+    # 出来上がる（モロヘイヤでの実測 / pooza/chubo2#69）。
+    #
+    # `Ginseng::Environment.jit?` は `defined?(RubyVM::YJIT)` ＝**ビルドに含まれて
+    # いるか**しか見ないので、`RubyVM::YJIT.enable if Environment.jit?` は
+    # 「入っていれば有効、入っていなければ黙って無効」になる。⚠ **後者になっても
+    # 誰も気づけない**のが問題。実例: ダイスキー staging (dev27) は rustup 導入済み
+    # なのに Ruby 4.0.6 が YJIT 抜きでビルドされていた（pooza/chubo2#123）。
+    #
+    # ⚠ **運用の関心は `yjit_available`（積まれているか）ではなく
+    # `yjit_enabled`（実際に効いているか）。**
+    #
+    # ⚠ **ここでは異常判定をしない。** 能力の欠落は障害ではなく、`/healthz` が
+    # 503 になるとサーバーが「停止」扱いになる。検知したい場合は Kuma の
+    # キーワード監視で `"yjit_enabled": true` を見る。
+    def self.ruby_health
+      return {
+        version: RUBY_VERSION,
+        # ⚠ `Ginseng::Environment.jit?` は `defined?(RubyVM::YJIT)` の戻りを
+        # そのまま返すので、真のとき **`"constant"`（String）** になる。JSON に
+        # 素で載せると boolean にならないので、ここで真偽へ倒す。
+        yjit_available: !jit?.nil?,
+        yjit_enabled: yjit_enabled?,
+      }
+    end
+
+    # ⚠ `jit?` は「ビルドに入っているか」。こちらは「いま効いているか」。
+    def self.yjit_enabled?
+      return false unless jit?
+      return RubyVM::YJIT.enabled? == true
+    end
+
     def self.db
       return File.join(
         dir,

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -121,6 +121,8 @@ module TomatoShrieker
       payload = {
         scheduler: scheduler_alive?,
         database: database_alive?,
+        # ⚠ 情報として出すだけで判定はしない (#1471)。詳細は Environment.ruby_health。
+        ruby: Environment.ruby_health,
         sources:,
       }
       return [200, JSON_HEADERS, ["#{JSON.pretty_generate(payload)}\n"]]

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -260,6 +260,25 @@ module TomatoShrieker
       assert_kind_of(Array, payload['sources'])
     end
 
+    # #1471: ランタイムの能力欠落を検知できるようにする。
+    #
+    # 🔴 YJIT は Rust の無い環境ではビルド時に黙って外れ、エラーにならないまま
+    # 24〜25% 遅いサーバーが出来上がる。⚠ **後者になっても誰も気づけない**ので、
+    # Kuma がキーワード監視で見られる形に出す。
+    def test_status_json_reports_ruby_runtime
+      _status, _headers, body = call('/status.json')
+      ruby = JSON.parse(body.first)['ruby']
+
+      assert_kind_of(Hash, ruby)
+      assert_equal(RUBY_VERSION, ruby['version'])
+      # ⚠ Ginseng::Environment.jit? は真のとき "constant"（String）を返す。
+      # JSON へ素で載せると boolean にならないので、真偽に倒れていることを見る。
+      assert_boolean(ruby['yjit_available'])
+      assert_boolean(ruby['yjit_enabled'])
+      # 積まれていなければ有効にはなりえない
+      assert_true(ruby['yjit_available']) if ruby['yjit_enabled']
+    end
+
     # #1433 / #1457 / #1470 で足した指標が全ソース分そろっていること
     def test_status_json_delivery_fields
       _status, _headers, body = call('/status.json')


### PR DESCRIPTION
closes #1471

`pooza/mulukhiya-toot-proxy#4466` と同じ対応を tomato へ。

## 🔴 YJIT は黙って外れる

**Rust の無い環境ではビルド時に黙って外れます。**エラーにならないまま「YJIT 抜きの Ruby」が完成し、バイトコード実行が **24〜25% 遅い**サーバーが出来上がります（モロヘイヤでの実測 / pooza/chubo2#69）。

```ruby
RubyVM::YJIT.enable if Environment.jit?   # jit? = defined?(RubyVM::YJIT)
```

⚠ **「入っていれば有効、入っていなければ黙って無効」**になり、**後者になっても誰も気づけません。**実例: ダイスキー staging (dev27) は rustup 導入済みなのに Ruby 4.0.6 が YJIT 抜きでビルドされていました（pooza/chubo2#123）。

## 変更

```json
{
  "scheduler": true,
  "database": true,
  "ruby": {"version": "4.0.6", "yjit_available": true, "yjit_enabled": true},
  "sources": [...]
}
```

- ⚠ **運用の関心は `yjit_available`（積まれているか）ではなく `yjit_enabled`（実際に効いているか）**なので両方出します
- ⚠ **判定はしません。**能力の欠落は障害ではなく、`/healthz` が 503 になるとサーバーが「停止」扱いになります。⚠ モロヘイヤは `/runtime/require_yjit` で opt-in にしていますが、**tomato の総合 `/healthz` は undelivered / silent すら見ていない**（#1508）ので、ここだけ判定を足すと一貫しません。**検知は Kuma のキーワード監視で `"yjit_enabled": true` を見る**形にします
- `/healthz` はテキスト応答なので触っていません（issue の指示どおり）

## ⚠ 見つけた落とし穴

`Ginseng::Environment.jit?` は `defined?(RubyVM::YJIT)` の戻りをそのまま返すので、**真のとき `"constant"`（String）**です。JSON へ素で載せると boolean になりません。`!jit?.nil?` で倒したうえで、テストで `assert_boolean` を掛けてあります。

## 検証

**227 tests / 0 failures / 0 errors**（3 回連続）、RuboCop 無指摘（89 files）。⚠ **`ruby:` の行を外すと新規テストが赤くなることを確認済み。**

本番の実測値: `{"version":"4.0.6","yjit_available":true,"yjit_enabled":true}`（oscura は問題なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)