### PR TITLE
fix: matrix-webhook 宛の CW を本文へ畳んで送る (#1493)

### DIFF
--- a/app/lib/tomato_shrieker/shrieker/tsunagal_webhook_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/tsunagal_webhook_shrieker.rb
@@ -1,0 +1,27 @@
+module TomatoShrieker
+  # [tsunagal/matrix-webhook](https://github.com/tsunagal/matrix-webhook) 宛の
+  # Shrieker (#1493)。
+  #
+  # ⚠⚠ **クラス名が `Matrix～` でないのは意図的。** 喋る相手は Matrix の
+  # Client-Server API ではなく **`tsunagal/matrix-webhook` という HTTP webhook**
+  # なので、`MatrixShrieker` は将来 C-S API を実装するときのために空けてある。
+  #
+  # 🔴 **matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ない。**
+  # 未知のフィールドは黙って無視されるので、`WebhookShrieker` が積む
+  # `spoiler_text` は **エラーにもならずに落ちていた**。同じソースをモロヘイヤと
+  # matrix-webhook の両方へ流すと、Matrix 宛だけ CW の内容が消える。
+  #
+  # ⚠ **Matrix に CW の標準は無い。** 独自の見せ方を決めることになるので、
+  # 「本文の先頭に畳んで送る」という最小の解釈にしてある。
+  class TsunagalWebhookShrieker < WebhookShrieker
+    # CW と本文を区切る空行。⚠ 1 行にすると CW が本文の一部に見える。
+    SEPARATOR = "\n\n".freeze
+
+    def build_body(body)
+      result = super
+      return result unless (spoiler_text = result.delete(:spoiler_text)).present?
+      result[:text] = [spoiler_text, result[:text]].reject(&:blank?).join(SEPARATOR)
+      return result
+    end
+  end
+end

--- a/app/lib/tomato_shrieker/shrieker/webhook_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/webhook_shrieker.rb
@@ -2,6 +2,29 @@ module TomatoShrieker
   class WebhookShrieker < SlackService
     include Package
 
+    # `/dest/hooks` の `type` と Shrieker の対応。
+    # ⚠ **クラスそのものではなく名前で持つ。** 定数の初期化はこのファイルの
+    # 読み込み時に走るので、クラスを直に書くと子クラスがまだ未定義で NameError
+    # になる（Zeitwerk の遅延ロードに任せる）。
+    CLASSES = {
+      'tsunagal' => 'TomatoShrieker::TsunagalWebhookShrieker',
+    }.freeze
+
+    # `/dest/hooks` の 1 要素から Shrieker を作る (#1493)。
+    #
+    # ⚠⚠ **`self.new` を差し替えてファクトリにしない。** 子クラスが継承した
+    # `new` から自分自身を作りに行き、無限再帰になる。呼び出し側は `create` を使う。
+    #
+    # ⚠ **種別は `type` キーの明示だけで決める。** `room_id` の有無のような
+    # 暗黙判定に頼らない。`channel` は Slack でも意味を持つので使えず、
+    # 「Matrix 固有なのは `room_id` だけ」という前提に乗ると、`channel` だけで
+    # 書かれた Tsunagal 宛（本番の 3 ソースがこの形）を取りこぼす。
+    def self.create(hook)
+      return new(hook) unless hook.is_a?(Hash)
+      name = CLASSES[hook.deep_symbolize_keys[:type].to_s]
+      return (name ? name.constantize : self).new(hook)
+    end
+
     def initialize(hook)
       case hook
       when Ginseng::URI
@@ -32,6 +55,14 @@ module TomatoShrieker
     end
 
     def create_body(body, type = :hash)
+      return build_body(body).to_json
+    end
+
+    # 送信する payload を Hash で組み立てる。⚠ **宛先ごとの差は `create_body`
+    # ではなくここを override して出す (#1493)。** `create_body` を丸ごと
+    # 差し替えると、下の `body[:template][:tag] = true` を落としやすい
+    # （#1484 が前提にしている）。
+    def build_body(body)
       body = body.clone
       body[:template][:tag] = true
       body[:text] = body[:template].to_s.strip
@@ -41,7 +72,7 @@ module TomatoShrieker
       body[:channel] ||= channel if channel
       body[:room_id] ||= room_id if room_id
       body.delete(:template)
-      return body.to_json
+      return body
     end
   end
 end

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -146,7 +146,8 @@ module TomatoShrieker
       yield piefed if piefed?
       yield nostr if nostr?
       (self['/dest/hooks'] || []).each do |hook|
-        yield WebhookShrieker.new(hook)
+        # ⚠ `new` ではなく `create`。hook の `type` で Shrieker を選ぶ (#1493)。
+        yield WebhookShrieker.create(hook)
       end
     end
 

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -220,6 +220,13 @@ properties:
                 url:
                   type: string
                   format: uri
+                # 宛先の種別 (#1493)。省略すると Slack 互換の素の Webhook 扱い。
+                # ⚠ room_id の有無のような暗黙判定はしないので、Tsunagal 宛は
+                # 明示すること。書かないと CW (spoiler_text) が黙って落ちる。
+                type:
+                  type: string
+                  enum:
+                    - tsunagal
                 channel:
                   type: string
                 room_id:

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -540,22 +540,33 @@ dest:
   hooks:
     - https://example.com/hook          # 従来どおりの URL 指定
     - url: https://example.com/webhook  # matrix-webhook 宛
+      type: tsunagal
       channel: '#alerts:example.com'    # ルームエイリアス
     - url: https://example.com/webhook
+      type: tsunagal
       room_id: '!AbCdEf:example.com'    # ルーム ID（channel との択一）
 ```
 
 | キー | 必須 | 内容 |
 |------|------|------|
 | `url` | 必須 | 送信先 Webhook URL |
+| `type` | 任意 | 宛先の種別。`tsunagal` のみ。省略すると Slack 互換の素の Webhook 扱い |
 | `channel` | 任意 | ルームエイリアス（`#name:server` 形式） |
 | `room_id` | 任意 | ルーム ID（`!xxxx:server` 形式） |
 
-⚠ **スキーマが `additionalProperties: false` なので、この 3 つ以外のキーは書けない。**`config/schema/source.yaml` の `hooks` を参照。
+⚠ **スキーマが `additionalProperties: false` なので、この 4 つ以外のキーは書けない。**`config/schema/source.yaml` の `hooks` を参照。
 
 ⚠ **`channel` / `room_id` は matrix-webhook 側の解釈**で、`WebhookShrieker` はペイロードに載せるだけ。Slack / Discord / モロヘイヤ宛に書いても無視される。
 
-⚠ **Matrix 宛では CW（`spoiler_text`）が表示されない (#1493)。**matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ないため、テンプレートに CW があっても**エラーにならずに内容が落ちる**。同じソースをモロヘイヤと matrix-webhook の両方へ流すと Matrix 宛だけ情報が欠ける。
+##### `type: tsunagal` — Tsunagal（matrix-webhook）宛 (#1493)
+
+🔴 **matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ない。**未知のフィールドは黙って無視されるので、`WebhookShrieker` が積む `spoiler_text` は**エラーにもならずに落ちていた**。同じソースをモロヘイヤと matrix-webhook の両方へ流すと、**Matrix 宛だけ CW の内容が消える。**
+
+`type: tsunagal` を書くと `TsunagalWebhookShrieker` が選ばれ、**CW を本文の先頭へ畳んで送る**（`spoiler_text` ＋ 空行 ＋ 本文）。⚠ **Matrix に CW の標準は無い**ので、これは独自の見せ方。
+
+⚠⚠ **`type` を書かないと従来どおり CW は落ちる。**`room_id` の有無のような暗黙判定は**しない** — `channel` は Slack でも意味を持つので判定に使えず、「Matrix 固有なのは `room_id` だけ」という前提に乗ると、**`channel` だけで書かれた宛先（本番の 3 ソースがこの形）を取りこぼす**。
+
+⚠ **クラス名が `Matrix～` でないのは意図的。**喋る相手は Matrix の Client-Server API ではなく `tsunagal/matrix-webhook` という HTTP webhook なので、`MatrixShrieker` は将来 C-S API を実装するときのために空けてある。
 
 ### モロヘイヤ連携
 

--- a/test/tsunagal_webhook_shrieker.rb
+++ b/test/tsunagal_webhook_shrieker.rb
@@ -1,0 +1,110 @@
+module TomatoShrieker
+  # #1493: matrix-webhook 宛で CW (spoiler_text) が黙って捨てられていた。
+  class TsunagalWebhookShriekerTest < TestCase
+    HOOK_URL = 'https://synapse.example.com/webhook'.freeze
+    SPOILER = 'ネタバレ注意'.freeze
+    TEXT = '本文です'.freeze
+
+    # ⚠ 種別は `type` の明示だけで決める。`room_id` の有無のような暗黙判定に
+    # 頼らない。`channel` は Slack でも意味を持つので判定に使えず、
+    # 「Matrix 固有なのは room_id だけ」という前提に乗ると、**channel だけで
+    # 書かれた宛先（本番の 3 ソースがこの形）を取りこぼす**。
+    def test_create_selects_by_type
+      assert_instance_of(
+        TsunagalWebhookShrieker,
+        WebhookShrieker.create('url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#x:example.com'),
+      )
+    end
+
+    def test_create_defaults_to_plain_webhook
+      assert_instance_of(WebhookShrieker, WebhookShrieker.create(HOOK_URL))
+      assert_instance_of(WebhookShrieker, WebhookShrieker.create('url' => HOOK_URL))
+      # ⚠ room_id があっても type が無ければ素の Webhook のまま
+      assert_instance_of(
+        WebhookShrieker,
+        WebhookShrieker.create('url' => HOOK_URL, 'room_id' => '!x:example.com'),
+      )
+    end
+
+    # 🔴 本題。matrix-webhook は text / channel / room_id / format しか見ないので、
+    # spoiler_text を積んでも黙って落ちる。本文の先頭へ畳んで送る。
+    def test_build_body_folds_spoiler_text_into_text
+      body = tsunagal.build_body(template: template(SPOILER))
+
+      assert_nil(body[:spoiler_text], 'matrix-webhook が見ないキーは送らない')
+      assert_include(body[:text], SPOILER)
+      assert_include(body[:text], TEXT)
+      assert_equal("#{SPOILER}\n\n#{TEXT}", body[:text])
+    end
+
+    # ⚠ CW が無いソースの本文を変えないこと。
+    def test_build_body_without_spoiler_text
+      assert_equal(TEXT, tsunagal.build_body(template: template(nil))[:text])
+    end
+
+    # 素の WebhookShrieker は従来どおり spoiler_text を別キーで送る
+    # （モロヘイヤは解釈できる）。
+    def test_plain_webhook_keeps_spoiler_text
+      body = WebhookShrieker.new(HOOK_URL).build_body(template: template(SPOILER))
+
+      assert_equal(SPOILER, body[:spoiler_text])
+      assert_equal(TEXT, body[:text])
+    end
+
+    # ⚠⚠ #1484 の前提。build_body を override するとき tag を落とさないこと。
+    def test_build_body_keeps_tag_flag
+      tmpl = template(SPOILER)
+      tsunagal.build_body(template: tmpl)
+
+      assert_true(tmpl[:tag])
+    end
+
+    # channel / room_id はそのまま載せる（matrix-webhook 側の解釈）。
+    def test_build_body_carries_room
+      shrieker = WebhookShrieker.create(
+        'url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#matrix-news:example.com',
+      )
+      body = shrieker.build_body(template: template(SPOILER))
+
+      assert_equal('#matrix-news:example.com', body[:channel])
+    end
+
+    # ⚠⚠ **Source の配線まで見る。** Shrieker 単体のテストだけだと、
+    # `Source#shriekers` が `create` ではなく `new` を呼ぶ実装に戻っても気づけない。
+    def test_source_shriekers_selects_tsunagal
+      source = Source.new(
+        'id' => '__test_tsunagal__',
+        'dest' => {
+          'hooks' => [
+            {'url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#x:example.com'},
+            'https://mstdn.example.com/mulukhiya/webhook/deadbeef',
+          ],
+        },
+      )
+
+      assert_equal(
+        [TsunagalWebhookShrieker, WebhookShrieker],
+        source.shriekers.map(&:class),
+      )
+    end
+
+    private
+
+    def tsunagal
+      return TsunagalWebhookShrieker.new(HOOK_URL)
+    end
+
+    # Template のふりをする最小の stub。⚠ 実 Template は ERB を評価するので、
+    # ここでは「to_s が本文を返し、source.spoiler_text を持つ」ことだけ満たす。
+    def template(spoiler_text)
+      source = Object.new
+      source.define_singleton_method(:spoiler_text) {spoiler_text}
+      stub = Object.new
+      stub.define_singleton_method(:to_s) {TEXT}
+      stub.define_singleton_method(:source) {source}
+      stub.define_singleton_method(:[]=) {|key, value| (@slots ||= {})[key] = value}
+      stub.define_singleton_method(:[]) {|key| (@slots ||= {})[key]}
+      return stub
+    end
+  end
+end


### PR DESCRIPTION
closes #1493

2026-08-08 の設計合意どおり、**対応先は tomato 側で完結**させます（Tsunagal 側の変更は待てない）。

## 症状

🔴 **matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ません。**未知のフィールドは黙って無視されるので、`WebhookShrieker` が積む `spoiler_text` は**エラーにもならずに落ちていました**。同じソースをモロヘイヤと matrix-webhook の両方へ流すと、**Matrix 宛だけ CW の内容が消えます。**

## 変更

### `TsunagalWebhookShrieker`

CW を**本文の先頭へ畳んで**送ります（`spoiler_text` ＋ 空行 ＋ 本文）。⚠ **Matrix に CW の標準は無い**ので、これは独自の見せ方です。最小の解釈にしてあります。

⚠⚠ **クラス名が `Matrix～` でないのは意図的。**喋る相手は Matrix の Client-Server API ではなく **`tsunagal/matrix-webhook` という HTTP webhook** なので、`MatrixShrieker` は将来 C-S API を実装するときのために空けてあります。

### `hooks` に `type` キー

```yaml
dest:
  hooks:
    - url: https://synapse.b-shock.org/webhook
      type: tsunagal            # ← 追加
      channel: '#matrix-news:synapse.b-shock.org'
    - https://mstdn.b-shock.org/mulukhiya/webhook/...
```

⚠⚠ **`room_id` の有無のような暗黙判定はしません。**`channel` は Slack でも意味を持つので判定に使えず、**「Matrix 固有なのは `room_id` だけ」という前提に乗ると、`channel` だけで書かれた宛先を取りこぼします**。🔴 **本番の matrix 系 3 ソースはまさに `channel` だけの形**です。

`WebhookShrieker.create(hook)` が `type` で選びます。⚠ **`self.new` は差し替えません** — 子クラスが継承した `new` から自分自身を作りに行き、無限再帰になります。

### `create_body` から `build_body` を切り出し

⚠ **宛先ごとの差は `build_body` を override して出します。**`create_body` を丸ごと差し替えると `body[:template][:tag] = true` を落としやすく、**#1484 がその前提に乗っています**。テストで固定しました。

## ⚠ 運用者向け — 設定の追加が要ります

**`type: tsunagal` を書かないと従来どおり CW は落ちます。**本番の 3 ソース（`matrix-news` / `matrix-element-web-release` / `matrix-synapse-release`）に 1 行足す作業が要ります。⚠ **既存の設定はそのままでも壊れません**（素の Webhook 扱いのまま）。

## 検証

**235 tests / 0 failures / 0 errors**、RuboCop 無指摘（91 files）。

⚠ **fix を外すと赤くなることを 2 系統で確認済み。**

- `build_body` の畳み込みを外す → `test_build_body_folds_spoiler_text_into_text`
- `Source#shriekers` を `create` → `new` に戻す → `test_source_shriekers_selects_tsunagal`

⚠ **2 つ目を先に書いていなければ、`Source` 側の配線が退行しても気づけませんでした**（Shrieker 単体のテストだけでは緑のまま通ります）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)