### PR TITLE
fix: 4.7.0 リリース前レビューの指摘に対応する

### DIFF
--- a/app/lib/tomato_shrieker/package.rb
+++ b/app/lib/tomato_shrieker/package.rb
@@ -88,8 +88,17 @@ module TomatoShrieker
 
     # マスクに失敗したとき、せめて例外クラス名だけは残す。⚠ 診断の手掛かりが
     # ゼロになると「マスクが壊れている」ことにも気付けない。
+    #
+    # ⚠⚠ **区切りは `': '`（コロン＋空白）。** `':'` で切ると
+    # `Ginseng::GatewayError` の名前空間で切れて **`Ginseng` しか残らない**。
+    # tomato の例外はほぼ全部 `Ginseng::` 配下なので、実質いつも壊れる。
+    #
+    # ⚠ 区切りが無い文字列は**丸ごと返さない**。呼び出し元は必ず
+    # `"#{error.class}: #{error.message}"` を渡すので通らない経路だが、
+    # ここで素通しにすると**マスクに失敗した本文がそのまま出る**。
     def self.error_class_of(message)
-      return message.to_s.split(':', 2).first.to_s
+      head, separator, = message.to_s.partition(': ')
+      return separator.empty? ? 'UnknownError' : head
     end
 
     def self.included(base)

--- a/app/lib/tomato_shrieker/sentry_scrubber.rb
+++ b/app/lib/tomato_shrieker/sentry_scrubber.rb
@@ -41,11 +41,23 @@ module TomatoShrieker
     rescue => e
       # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。
       # 素通しで送ると、伏せるはずだった値がそのまま外部サービスへ出る。
-      warn "Sentry event dropped (scrub failed): #{e.class}"
+      report_drop(e)
       return nil
     end
 
     private
+
+    # 🔴 **`warn` で出してはいけない。** `bin/scheduler_daemon.rb` が
+    # `$stderr.reopen(File::NULL)` するので、**本番では丸ごと消える**。
+    # ここが見えないと「scrub が壊れて Sentry へ何も届かないのに、誰も気づけない」
+    # という #1467 の目的と正反対の状態になる。
+    #
+    # ⚠ ログ自体が落ちても before_send を巻き込まない（イベントは落とす側に倒す）。
+    def report_drop(error)
+      @logger.error(sentry: 'before_send', message: 'event dropped (scrub failed)', error:)
+    rescue StandardError
+      return nil
+    end
 
     # 例外メッセージ本体。⚠ **ここが tomato でいちばん漏れる場所。**
     # `SingleExceptionInterface#value` だけが writable。

--- a/test/package.rb
+++ b/test/package.rb
@@ -54,6 +54,25 @@ module TomatoShrieker
       assert_include(message, 'vjump-youtube')
     end
 
+    # ⚠⚠ マスクに失敗したときのフォールバックが、名前空間付きのクラス名で
+    # 壊れないこと。`':'` で切ると `Ginseng::GatewayError` が `Ginseng` になる。
+    # tomato の例外はほぼ全部 `Ginseng::` 配下なので実質いつも壊れていた。
+    def test_error_class_of
+      assert_equal(
+        'Ginseng::GatewayError',
+        Package.error_class_of('Ginseng::GatewayError: Bad response 404 (https://x/y)'),
+      )
+      assert_equal('RuntimeError', Package.error_class_of('RuntimeError: boom'))
+    end
+
+    # 🔴 区切りが無い文字列を丸ごと返さないこと。素通しにすると、マスクに失敗した
+    # 本文がそのまま出る。
+    def test_error_class_of_does_not_pass_through
+      message = 'https://precure.ml/mulukhiya/webhook/SECRET'
+
+      assert_not_include(Package.error_class_of(message), 'SECRET')
+    end
+
     # ⚠ 不正なバイト列でもマスクごと素通りしないこと (#518 / #1469 の族)。
     # to_utf8 の後にマスクを通しているかを見る。
     def test_error_message_masks_broken_bytes

--- a/test/sentry_scrubber.rb
+++ b/test/sentry_scrubber.rb
@@ -71,6 +71,32 @@ module TomatoShrieker
       assert_nil(@scrubber.scrub(event))
     end
 
+    # 🔴 **落としたことをログに残すこと。** `warn` は本番で `/dev/null`
+    # （scheduler_daemon が stderr を潰す）なので、そこへ出すと「Sentry へ何も
+    # 届かないのに誰も気づけない」になる。
+    def test_scrub_logs_when_event_is_dropped
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+      logged = []
+      @scrubber.instance_variable_get(:@logger).define_singleton_method(:error) do |arg|
+        logged.push(arg)
+      end
+
+      @scrubber.scrub(event)
+
+      assert_equal(1, logged.size, 'イベントを黙って捨てている')
+      assert_equal('before_send', logged.first[:sentry])
+    end
+
+    # ⚠ ログ自体が落ちても before_send を巻き込まないこと。
+    def test_scrub_survives_logger_failure
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+      @scrubber.instance_variable_get(:@logger).define_singleton_method(:error) {|_arg| raise 'logger boom'}
+
+      assert_nothing_raised {assert_nil(@scrubber.scrub(event))}
+    end
+
     private
 
     def error_event(error)


### PR DESCRIPTION
4.7.0 のリリース前レビュー（5 観点）で出た指摘のうち、**赤 1 件と 1 行で直る黄 1 件**を入れます。

⚠ **今回は並列サブエージェントではなく、5 観点を私が順に見ました。**

## 🔴 赤: scrub 失敗が本番では見えない

`SentryScrubber#scrub` は失敗したイベントを落とし（fail closed・正しい）、`warn` で通知していました。🔴 **ところが `bin/scheduler_daemon.rb` は `$stderr.reopen(File::NULL)` するので、本番ではこの通知が丸ごと消えます。**

⚠⚠ **scrub が壊れると「Sentry へ何も届かないのに誰も気づけない」**という、#1467 の目的と正反対の状態になります。`logger.error` へ移しました。

⚠ ログ自体が落ちても `before_send` を巻き込まないよう、`report_drop` の中で握っています（イベントは落とす側に倒す）。

## 🟡 黄: `error_class_of` が名前空間付きクラス名で壊れる

```ruby
'Ginseng::GatewayError: Bad response 404 (https://x/y)'.split(':', 2).first
#=> "Ginseng"     ← 名前空間で切れている
```

**tomato の例外はほぼ全部 `Ginseng::` 配下**なので、実質いつも壊れていました。区切りを `': '`（コロン＋空白）にします。

⚠ **区切りが無い文字列は丸ごと返さず `UnknownError` に倒します。**素通しにすると、**マスクに失敗した本文がそのまま出ます**（テストで固定）。

## レビューで確認して問題なかったもの

- ✅ **本番の 39 ソース定義が新スキーマ（`type` 追加）で全部 OK**（oscura 上で `source validate` を実行）
- ✅ `redact_expired` の WHERE は `source_run_log_executed_at_index` に乗る
- ✅ `Config#load` は reload しても件数が一定（並行読み出しテストで固定済み）
- ✅ `DeliveryStats` の集約は `attempted_count` / `failure_count` の別を保っている（既存テスト 4 件が守っている）

## 🟢 緑（次リリースへ送り）

- **マスク設定の memo 化で `SentryScrubber` だけ `Config#reload` が効かない** → **#1538**（4.8.0）。⚠ いまは実害ゼロで、#1459 が入ると顔を出す
- `Config#source_entries` / `DeliveryStats#record_attempted_failure` が public（内部ヘルパ）
- `Ginseng::Masking#mask` が Hash の空値キーを落とし、キーを symbolize する（Sentry payload が微差）

## 検証

**239 tests / 0 failures / 0 errors**、RuboCop 無指摘（91 files）。⚠ **fix を外すと新規 2 件が赤くなることを確認済み。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)