### PR TITLE
4.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
-  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.4', require: false
   gem 'ricecream'
   gem 'rubocop-sequel'
   gem 'test-unit'

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'sqlite3'
 gem 'thor'
 
 group :development do
-  gem 'ginseng-style', github: 'pooza/ginseng-style', branch: 'main', require: false
+  gem 'ginseng-style', github: 'pooza/ginseng-style', tag: 'v1.1.0', require: false
   gem 'ricecream'
   gem 'rubocop-sequel'
   gem 'test-unit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: e445a60500fc8ebd50a4ef4c7a20f032dd927ef5
+  revision: 8443ae749e35a49a49751828f4e58c522c8d1eb8
   branch: main
   specs:
-    ginseng-core (1.19.0)
+    ginseng-core (1.20.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
@@ -34,14 +34,14 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 9b2fdd584ef72de24ff860dd10803cee00bddf8b
+  revision: 8b23e095d68674d18840ea782c15c560202f3adb
   branch: main
   specs:
-    ginseng-fediverse (1.8.28)
+    ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: 4c8b94d71eb85fcc77e728c1ff1416100cc545d7
+  revision: 1150891191edb02dbbc60153a375b1756b0bd943
   branch: main
   specs:
     ginseng-piefed (0.1.1)
@@ -59,7 +59,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: b27af86e1a9e60bf254fb06ebebb771575d6ffa1
+  revision: f041de996b98a6d24df07c5fcd70893290206f68
   branch: main
   specs:
     ginseng-youtube (2.0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: 86738fedd657d3203e88038ce3b27def51ea971e
-  branch: main
+  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
+  tag: v1.1.0
   specs:
-    ginseng-style (1.0.0)
+    ginseng-style (1.1.0)
       rubocop
       rubocop-minitest
       rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,10 +48,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: fd65197dbb08ef209e2c54734b4a80b72481da58
-  tag: v1.1.0
+  revision: 0c9ddb19d902d675504fc2d6ed258e590901073f
+  tag: v1.1.4
   specs:
-    ginseng-style (1.1.0)
+    ginseng-style (1.1.4)
       rubocop
       rubocop-minitest
       rubocop-performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,7 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-style.git
-  revision: 2474936f5598640c9cf8464f71195c2bb03e4309
+  revision: 86738fedd657d3203e88038ce3b27def51ea971e
   branch: main
   specs:
     ginseng-style (1.0.0)
@@ -222,7 +222,7 @@ GEM
     regexp_parser (2.12.0)
     rexml (3.4.4)
     ricecream (0.2.1)
-    rubocop (1.88.2)
+    rubocop (1.89.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -240,9 +240,9 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.38.0, < 2.0)
-    rubocop-performance (1.26.1)
+    rubocop-performance (1.27.0)
       lint_roller (~> 1.1)
-      rubocop (>= 1.75.0, < 2.0)
+      rubocop (>= 1.89.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
     rubocop-rake (0.7.1)
       lint_roller (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 8443ae749e35a49a49751828f4e58c522c8d1eb8
+  revision: 430ad064e94c3e8cea53cd1d5d8b3b4b32a723dc
   branch: main
   specs:
-    ginseng-core (1.20.0)
+    ginseng-core (1.22.0)
       activesupport (>= 7.0.7.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)

--- a/app/lib/tomato_shrieker.rb
+++ b/app/lib/tomato_shrieker.rb
@@ -20,11 +20,19 @@ module TomatoShrieker
   def self.setup_sentry
     dsn = Config.instance['/sentry/dsn']
     return unless dsn
+    # ⚠⚠ **マスクを Sentry.init の外で用意する (#1467)。** 中で組み立てると、
+    # 失敗が下の rescue に落ちて「Sentry は初期化されないが警告だけ出る」形になり、
+    # **マスクが無いまま送る状態には決してしない**という意図が読めなくなる。
+    # ここで raise すれば Sentry ごと立ち上がらない ＝ fail closed。
+    scrubber = SentryScrubber.new
     Sentry.init do |config|
       config.dsn = dsn
       config.release = Package.version
       config.environment = Environment.type
       config.traces_sample_rate = Config.instance['/sentry/traces_sample_rate'] || 0
+      # ⚠ `send_default_pii` は既定 false のまま。問題は「自分で例外メッセージへ
+      # 埋めているぶん」なので、既定値では守れない。
+      config.before_send = proc {|event, _hint| scrubber.scrub(event)}
     end
   rescue => e
     warn "Sentry initialization skipped: #{e.message}"

--- a/app/lib/tomato_shrieker/cli/source_command.rb
+++ b/app/lib/tomato_shrieker/cli/source_command.rb
@@ -132,8 +132,7 @@ module TomatoShrieker
       SilenceAck.acknowledge(id)
       say "#{id} を確認済みにしました。"
       # ⚠ 「今後も問題ない」の保証ではないことを操作のたびに示す。
-      days = source.monitor_silence_tolerance_seconds / 86_400
-      say "  次に silence_tolerance (#{days}日) を超えたら、再び警告します。"
+      say "  次に silence_tolerance (#{tolerance_label(source)}) を超えたら、再び警告します。"
     end
 
     desc 'validate [ID]', 'ソース定義を JSON Schema で検証（ID 省略時は全件）'
@@ -162,6 +161,20 @@ module TomatoShrieker
     end
 
     private
+
+    # silence_tolerance を人が読める長さで返す (#1513)。
+    #
+    # ⚠ **整数除算で「0日」と出してはいけない。** スキーマは `12h` / `30m` を許す
+    # ので（`^((\d+(\.\d+)?[smhdwMy])+|\d+(\.\d+)?)$`）、日未満を設定した
+    # ソースでは「次に silence_tolerance (0日) を超えたら」と出ていた。
+    # ⚠ #1496 の「9 月上旬に 7d → 3d へ締める」運用で日未満を入れたら踏む。
+    def tolerance_label(source)
+      seconds = source.monitor_silence_tolerance_seconds
+      return "#{seconds / 86_400}日" if (seconds % 86_400).zero?
+      return "#{seconds / 3_600}時間" if (seconds % 3_600).zero?
+      return "#{seconds / 60}分" if (seconds % 60).zero?
+      return "#{seconds}秒"
+    end
 
     def find_source!(id, klass = nil)
       sources = klass ? klass.all : Source.all

--- a/app/lib/tomato_shrieker/config.rb
+++ b/app/lib/tomato_shrieker/config.rb
@@ -2,17 +2,38 @@ module TomatoShrieker
   class Config < Ginseng::Config
     include Package
 
+    # 🔴 **ファイルを全部読み切ってから、self へは 1 回だけ書く (#1530)。**
+    #
+    # 以前は `self['/sources']` へ 1 件ずつ push していた。2 つの穴があった。
+    #
+    # 1. **途中で失敗すると戻せない。** 1 ファイルが `Psych::SyntaxError` を
+    #    上げると、`/sources` は**途中まで積まれた状態で残る**。⚠ ソース定義を
+    #    手で 1 文字打ち間違えただけで、稼働中のソース一覧が壊れた
+    # 2. **途中経過が監視から見える。** push している間 `/sources` は短いまま。
+    #    ⚠ `/status.json` は全ソースを舐めるので約 900ms かかり（#1472）、
+    #    この窓に重なると**ソースが欠けて見える**。`/healthz/source/:id` は
+    #    `Source.create(id)` が見つからず **404** を返す。Kuma に偽の 404 / 503 が出る
+    #
+    # ⚠ **`source_entries` を `super` より先に呼ぶこと。** ファイル I/O を先に
+    # 済ませておけば、`super` の `update` と下の代入の間に I/O が挟まらず、
+    # 窓はマイクロ秒まで縮む。壊れた YAML があれば `self` を一切変更しないまま
+    # raise するので、呼び出し側は前の内容のまま走り続ける。
+    #
+    # ⚠ `+` で新しい配列を作る。`super` が返す配列は `@raw` の実体そのものなので、
+    # そこへ push すると load のたびに積み増さる（ginseng-core#491）。
     def load
+      entries = source_entries
       super
-      # super が返す配列は @raw の実体そのもの。直に push すると load を呼ぶたびに
-      # ソース定義が積み増され、同じソースが多重登録される。複製してから積む。
-      self['/sources'] = self['/sources'].dup
-      suffixes.each do |suffix|
-        Dir.glob(File.join(Environment.dir, 'config/sources', "*#{suffix}")).each do |f|
-          key = File.basename(f, suffix)
+      self['/sources'] = self['/sources'] + entries
+    end
+
+    # `config/sources/*.yaml` を読んで配列にする。⚠ self には触らない。
+    def source_entries
+      return suffixes.flat_map do |suffix|
+        Dir.glob(File.join(Environment.dir, 'config/sources', "*#{suffix}")).map do |f|
           values = YAML.load_file(f)
-          values['id'] ||= key
-          self['/sources'].push(values)
+          values['id'] ||= File.basename(f, suffix)
+          values
         end
       end
     end

--- a/app/lib/tomato_shrieker/delivery_stats.rb
+++ b/app/lib/tomato_shrieker/delivery_stats.rb
@@ -23,24 +23,14 @@ module TomatoShrieker
     end
 
     def record_error(shrieker, error)
-      @mutex.synchronize do
-        @attempted_count += 1
-        @shrieker_errors[shrieker.class.to_s] += 1
-        @errors.push(error)
-      end
-      return nil
+      return record_attempted_failure(shrieker.class, error)
     end
 
     # 設定されているのに Shrieker を組み立てられなかった宛先 (#1504)。
     # アクセサが例外を握って nil を返すため、この宛先は shriekers から消える。
     # attempted に載せないと「宛先ゼロで完走した run」＝緑になる。
     def record_unavailable(kind, error)
-      @mutex.synchronize do
-        @attempted_count += 1
-        @shrieker_errors[kind.to_s] += 1
-        @errors.push(error)
-      end
-      return nil
+      return record_attempted_failure(kind, error)
     end
 
     # 配信まで到達せずに落ちた失敗。Shrieker が特定できない経路（FeedSource#fetch の
@@ -63,6 +53,25 @@ module TomatoShrieker
 
     def shrieker_errors
       return @mutex.synchronize {@shrieker_errors.dup}
+    end
+
+    # 「宛先に触ったが届かなかった」失敗の共通処理 (#1490)。
+    #
+    # ⚠⚠ **record_failure と一本化してはいけない。** 見た目は似ているが
+    # **`@attempted_count` と `@failure_count` で別の数を数えている**。
+    # `record_failure` は宛先に一度も触れていない失敗なので attempted に載せず、
+    # 載せると `delivered < attempted` が成立して `undelivered?`（#1504）が嘘で
+    # 立つ。⚠ しかも解除は「次に全宛先へ届く run」だけなので、疎なソースは
+    # 数週間 503 に貼り付く。
+    #
+    # ⚠ `kind` は Class でも文字列でもよい（`to_s` で同じ値になる）。
+    def record_attempted_failure(kind, error)
+      @mutex.synchronize do
+        @attempted_count += 1
+        @shrieker_errors[kind.to_s] += 1
+        @errors.push(error)
+      end
+      return nil
     end
 
     def error_count

--- a/app/lib/tomato_shrieker/environment.rb
+++ b/app/lib/tomato_shrieker/environment.rb
@@ -34,6 +34,41 @@ module TomatoShrieker
       return type == 'production'
     end
 
+    # ランタイムの能力欠落を可視化する (#1471)。
+    #
+    # 🔴 **YJIT は Rust の無い環境ではビルド時に黙って外れる。** エラーにならない
+    # まま「YJIT 抜きの Ruby」が完成し、バイトコード実行が 24〜25% 遅いサーバーが
+    # 出来上がる（モロヘイヤでの実測 / pooza/chubo2#69）。
+    #
+    # `Ginseng::Environment.jit?` は `defined?(RubyVM::YJIT)` ＝**ビルドに含まれて
+    # いるか**しか見ないので、`RubyVM::YJIT.enable if Environment.jit?` は
+    # 「入っていれば有効、入っていなければ黙って無効」になる。⚠ **後者になっても
+    # 誰も気づけない**のが問題。実例: ダイスキー staging (dev27) は rustup 導入済み
+    # なのに Ruby 4.0.6 が YJIT 抜きでビルドされていた（pooza/chubo2#123）。
+    #
+    # ⚠ **運用の関心は `yjit_available`（積まれているか）ではなく
+    # `yjit_enabled`（実際に効いているか）。**
+    #
+    # ⚠ **ここでは異常判定をしない。** 能力の欠落は障害ではなく、`/healthz` が
+    # 503 になるとサーバーが「停止」扱いになる。検知したい場合は Kuma の
+    # キーワード監視で `"yjit_enabled": true` を見る。
+    def self.ruby_health
+      return {
+        version: RUBY_VERSION,
+        # ⚠ `Ginseng::Environment.jit?` は `defined?(RubyVM::YJIT)` の戻りを
+        # そのまま返すので、真のとき **`"constant"`（String）** になる。JSON に
+        # 素で載せると boolean にならないので、ここで真偽へ倒す。
+        yjit_available: !jit?.nil?,
+        yjit_enabled: yjit_enabled?,
+      }
+    end
+
+    # ⚠ `jit?` は「ビルドに入っているか」。こちらは「いま効いているか」。
+    def self.yjit_enabled?
+      return false unless jit?
+      return RubyVM::YJIT.enabled? == true
+    end
+
     def self.db
       return File.join(
         dir,

--- a/app/lib/tomato_shrieker/model/source_run_log.rb
+++ b/app/lib/tomato_shrieker/model/source_run_log.rb
@@ -104,9 +104,29 @@ module TomatoShrieker
 
     def self.prune(retention_days)
       cutoff = Time.now - (retention_days * 86_400)
+      count = where(Sequel.lit('executed_at < ?', cutoff))
+        .exclude(id: last_delivered_ids).exclude(id: first_run_ids)
+        .exclude(id: last_attempted_ids).delete
+      redact_expired(cutoff)
+      return count
+    end
+
+    # 🔴 **retention を過ぎても残す保護行から error_message を落とす (#1511)。**
+    #
+    # 保護行は 3 系統に増え、**ソースあたり最大 3 行が retention_days を超えて
+    # 無期限に残る**ようになった。⚠ とくに `last_attempted_ids` が守る行は
+    # 「直近の配信試行」＝ `partial` / `error` で `error_message` を持つ可能性が
+    # 最も高い。`/monitor/retention_days` が担保していた「例外メッセージは
+    # N 日で消える」という上限が、保護行だけ外れていた。
+    #
+    # ⚠ **削除の後に呼ぶこと。** 保護されていない期限切れ行は先に消えているので、
+    # ここで残っている期限切れ行は保護行だけになる。
+    #
+    # ⚠ 判定に使うのは `executed_at` / `attempted_count` / `delivered_count` だけ
+    # なので、`error_message` を落としても保護の意味は失われない。
+    def self.redact_expired(cutoff)
       return where(Sequel.lit('executed_at < ?', cutoff))
-          .exclude(id: last_delivered_ids).exclude(id: first_run_ids)
-          .exclude(id: last_attempted_ids).delete
+          .exclude(error_message: nil).update(error_message: nil)
     end
 
     # 「最後に配信できた時刻」の根拠行はソースごとに 1 行だけ prune から守る。

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 
 module TomatoShrieker
@@ -89,7 +91,11 @@ module TomatoShrieker
 
     # #1470: 配信できていないこと自体を出す
     def silent_body(source)
-      body = "silent: true\n"
+      # ⚠ `+` を付けて可変にする (#1512)。式展開の無いリテラルは将来 frozen に
+      # なるので、`<<` すると FrozenError で healthz_source の rescue に落ち、
+      # **503 の本文が診断情報を丸ごと失う**（ステータスは 503 のままなので
+      # Kuma は気づかない）。
+      body = +"silent: true\n"
       body << "last_delivered_at: #{source.last_delivered_at&.iso8601}\n"
       body << "silence_tolerance_seconds: #{source.monitor_silence_tolerance_seconds}\n"
       body << "noop_streak: #{SourceRunLog.noop_streak(source.id)}\n"
@@ -102,7 +108,8 @@ module TomatoShrieker
     # #1504: 「いつ・何件のうち何件が届かなかったか」を運用者に見せる。
     # ⚠ 宛先の識別子は持たないので「どの宛先か」は出せない。設定を見て切り分ける。
     def undelivered_body(log)
-      body = "undelivered: true\n"
+      # ⚠ 式展開の無いリテラルなので `+` で可変にする (#1512)。上の silent_body 参照。
+      body = +"undelivered: true\n"
       body << "last_attempted_at: #{log.executed_at.iso8601}\n"
       body << "attempted_count: #{log.attempted_count}\n"
       body << "delivered_count: #{log.delivered_count}\n"

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -121,6 +121,8 @@ module TomatoShrieker
       payload = {
         scheduler: scheduler_alive?,
         database: database_alive?,
+        # ⚠ 情報として出すだけで判定はしない (#1471)。詳細は Environment.ruby_health。
+        ruby: Environment.ruby_health,
         sources:,
       }
       return [200, JSON_HEADERS, ["#{JSON.pretty_generate(payload)}\n"]]

--- a/app/lib/tomato_shrieker/package.rb
+++ b/app/lib/tomato_shrieker/package.rb
@@ -61,7 +61,35 @@ module TomatoShrieker
     # 「エラーを報告しようとして同じ例外を踏む」を避けるため、rescue 節の中でも通す。
     def self.error_message(error)
       return nil unless error
-      return "#{error.class}: #{error.message}".to_utf8
+      return mask_credentials("#{error.class}: #{error.message}".to_utf8)
+    end
+
+    # 🔴 **例外メッセージに埋まった資格情報を落とす (#1511)。**
+    #
+    # アプリは URL を丸ごとメッセージへ埋める。
+    #
+    #   raise Ginseng::GatewayError, "Invalid feed #{id} (#{uri}) #{e.message}"
+    #
+    # ここを通った文字列は **`source_run_log.error_message` に保存され**、
+    # `/status.json` と `/healthz/source` からそのまま読める。⚠ 本番の
+    # `monitor.bind` は `0.0.0.0` なので、LAN / VPN の誰からでも見える (#1531)。
+    #
+    # ⚠⚠ **`to_utf8` の後に通すこと。** 不正なバイト列のまま gsub すると
+    # ArgumentError になり、**マスクごと素通りする** (#518 で踏んだ型)。
+    #
+    # ⚠ マスクの正本は `Ginseng::Masking`。ここで同等品を書かない (#1467)。
+    def self.mask_credentials(message)
+      return Logger.new.mask_urls_in(message)
+    rescue => e
+      # 🔴 **fail closed。** マスクを通せなかった文字列は出さない。素通しにすると
+      # 伏せるはずだった値が run_log と監視エンドポイントへ残る。
+      return "#{error_class_of(message)} (masking failed: #{e.class})"
+    end
+
+    # マスクに失敗したとき、せめて例外クラス名だけは残す。⚠ 診断の手掛かりが
+    # ゼロになると「マスクが壊れている」ことにも気付けない。
+    def self.error_class_of(message)
+      return message.to_s.split(':', 2).first.to_s
     end
 
     def self.included(base)

--- a/app/lib/tomato_shrieker/package.rb
+++ b/app/lib/tomato_shrieker/package.rb
@@ -88,8 +88,17 @@ module TomatoShrieker
 
     # マスクに失敗したとき、せめて例外クラス名だけは残す。⚠ 診断の手掛かりが
     # ゼロになると「マスクが壊れている」ことにも気付けない。
+    #
+    # ⚠⚠ **区切りは `': '`（コロン＋空白）。** `':'` で切ると
+    # `Ginseng::GatewayError` の名前空間で切れて **`Ginseng` しか残らない**。
+    # tomato の例外はほぼ全部 `Ginseng::` 配下なので、実質いつも壊れる。
+    #
+    # ⚠ 区切りが無い文字列は**丸ごと返さない**。呼び出し元は必ず
+    # `"#{error.class}: #{error.message}"` を渡すので通らない経路だが、
+    # ここで素通しにすると**マスクに失敗した本文がそのまま出る**。
     def self.error_class_of(message)
-      return message.to_s.split(':', 2).first.to_s
+      head, separator, = message.to_s.partition(': ')
+      return separator.empty? ? 'UnknownError' : head
     end
 
     def self.included(base)

--- a/app/lib/tomato_shrieker/sentry_scrubber.rb
+++ b/app/lib/tomato_shrieker/sentry_scrubber.rb
@@ -41,11 +41,23 @@ module TomatoShrieker
     rescue => e
       # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。
       # 素通しで送ると、伏せるはずだった値がそのまま外部サービスへ出る。
-      warn "Sentry event dropped (scrub failed): #{e.class}"
+      report_drop(e)
       return nil
     end
 
     private
+
+    # 🔴 **`warn` で出してはいけない。** `bin/scheduler_daemon.rb` が
+    # `$stderr.reopen(File::NULL)` するので、**本番では丸ごと消える**。
+    # ここが見えないと「scrub が壊れて Sentry へ何も届かないのに、誰も気づけない」
+    # という #1467 の目的と正反対の状態になる。
+    #
+    # ⚠ ログ自体が落ちても before_send を巻き込まない（イベントは落とす側に倒す）。
+    def report_drop(error)
+      @logger.error(sentry: 'before_send', message: 'event dropped (scrub failed)', error:)
+    rescue StandardError
+      return nil
+    end
 
     # 例外メッセージ本体。⚠ **ここが tomato でいちばん漏れる場所。**
     # `SingleExceptionInterface#value` だけが writable。

--- a/app/lib/tomato_shrieker/sentry_scrubber.rb
+++ b/app/lib/tomato_shrieker/sentry_scrubber.rb
@@ -1,0 +1,78 @@
+module TomatoShrieker
+  # Sentry へ送るイベントから資格情報を落とす (#1467)。
+  #
+  # 🔴 **ログでは伏せている値が、例外イベントとしては素通りしていた。**
+  # `sentry-ruby` の `send_default_pii` は既定 false だが、守られるのは
+  # リクエストヘッダ等であって、**アプリが自分で例外メッセージへ埋めた値**は
+  # 対象外。tomato はまさにそれをやっている。
+  #
+  #   raise Ginseng::GatewayError, "Invalid feed #{id} (#{uri}) #{e.message}"
+  #
+  # ⚠⚠ **マスクの正本は `Ginseng::Logger`。** ここで同等品を書くと、対象の列が
+  # ログ側と 2 か所に分かれて必ずズレる。`/logger/mask_fields` /
+  # `/logger/mask_query_params` / `/logger/mask_url_paths` を唯一の正本に保つため、
+  # gem 側の `mask` / `mask_url` をそのまま呼ぶ（pooza/ginseng-core#580 で public
+  # になった）。
+  class SentryScrubber
+    include Package
+
+    # ⚠ **ここで logger を掴んでおく。** イベントごとに new すると、マスク設定の
+    # 読み出しがイベント送信時の文脈に移る。初期化時に解決しておけば、設定が
+    # 読めないときは Sentry ごと立ち上がらない（fail closed）。
+    def initialize
+      @logger = logger
+      # 設定が読めることをここで確かめる。⚠ 読めないまま before_send に入ると、
+      # 「マスク対象ゼロ ＝ 素通し」で送り続けることになる。
+      @logger.mask_url('https://example.com/?token=probe')
+    end
+
+    # ⚠ **必ず event を返すこと。** `before_send` が `Sentry::ErrorEvent` 以外を
+    # 返すとイベントは破棄される（sentry-ruby 6.6.2 の client.rb）。
+    def scrub(event)
+      scrub_exceptions(event)
+      event.message = mask(event.message) if event.message.is_a?(String)
+      event.transaction = mask(event.transaction) if event.transaction.is_a?(String)
+      event.extra = mask(event.extra)
+      event.tags = mask(event.tags)
+      event.contexts = mask(event.contexts)
+      event.user = mask(event.user)
+      scrub_breadcrumbs(event)
+      return event
+    rescue => e
+      # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。
+      # 素通しで送ると、伏せるはずだった値がそのまま外部サービスへ出る。
+      warn "Sentry event dropped (scrub failed): #{e.class}"
+      return nil
+    end
+
+    private
+
+    # 例外メッセージ本体。⚠ **ここが tomato でいちばん漏れる場所。**
+    # `SingleExceptionInterface#value` だけが writable。
+    def scrub_exceptions(event)
+      # ⚠ 局所変数へ受けてから回す。`event.exception` は Hash ではなく
+      # `Sentry::ExceptionInterface`（`values` は Array）なので、`each_value` は
+      # 生えていない。RuboCop の Style/HashEachMethods を誤爆させないため。
+      entries = event.exception&.values
+      return unless entries
+      entries.each do |entry|
+        entry.value = mask(entry.value) if entry.value.is_a?(String)
+      end
+    end
+
+    def scrub_breadcrumbs(event)
+      event.breadcrumbs&.buffer&.each do |crumb|
+        next unless crumb
+        crumb.message = mask(crumb.message) if crumb.message.is_a?(String)
+        crumb.data = mask(crumb.data) if crumb.data.is_a?(Hash)
+      end
+    end
+
+    # ⚠ `Ginseng::Logger#mask` は Hash / Array / String を再帰的に処理し、
+    # `mask_fields` のキーは**値ごと落とす**。String は `mask_url` を通る。
+    def mask(value)
+      return value unless value.is_a?(String) || value.is_a?(Hash) || value.is_a?(Array)
+      return @logger.mask(value)
+    end
+  end
+end

--- a/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/piefed_shrieker.rb
@@ -5,7 +5,6 @@ module TomatoShrieker
       params[:url] = "https://#{params[:host]}" if params[:host] && !params[:url]
       params[:user] = params[:user_id] if params[:user_id] && !params[:user]
       super
-      login
     end
 
     def api_version
@@ -13,6 +12,11 @@ module TomatoShrieker
     end
 
     def exec(body)
+      # ⚠ **構築時ではなくここで login する (#1514)。**上流の `Service#login` は
+      # `return if @jwt` を持つので、二重に叩くことはない。構築時に無条件で叩くと、
+      # 投稿しないケース（設定の読み込み・`source list`・テストの初期化）でも
+      # PieFed の認証 API を叩き、レートリミット (429) を踏みやすくなる。
+      login
       template = create_piefed_template(body[:template])
       data = {
         title: template.to_s.gsub(/[\r\n[:blank:]]+/, ' '),

--- a/app/lib/tomato_shrieker/shrieker/tsunagal_webhook_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/tsunagal_webhook_shrieker.rb
@@ -1,0 +1,27 @@
+module TomatoShrieker
+  # [tsunagal/matrix-webhook](https://github.com/tsunagal/matrix-webhook) 宛の
+  # Shrieker (#1493)。
+  #
+  # ⚠⚠ **クラス名が `Matrix～` でないのは意図的。** 喋る相手は Matrix の
+  # Client-Server API ではなく **`tsunagal/matrix-webhook` という HTTP webhook**
+  # なので、`MatrixShrieker` は将来 C-S API を実装するときのために空けてある。
+  #
+  # 🔴 **matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ない。**
+  # 未知のフィールドは黙って無視されるので、`WebhookShrieker` が積む
+  # `spoiler_text` は **エラーにもならずに落ちていた**。同じソースをモロヘイヤと
+  # matrix-webhook の両方へ流すと、Matrix 宛だけ CW の内容が消える。
+  #
+  # ⚠ **Matrix に CW の標準は無い。** 独自の見せ方を決めることになるので、
+  # 「本文の先頭に畳んで送る」という最小の解釈にしてある。
+  class TsunagalWebhookShrieker < WebhookShrieker
+    # CW と本文を区切る空行。⚠ 1 行にすると CW が本文の一部に見える。
+    SEPARATOR = "\n\n".freeze
+
+    def build_body(body)
+      result = super
+      return result unless (spoiler_text = result.delete(:spoiler_text)).present?
+      result[:text] = [spoiler_text, result[:text]].reject(&:blank?).join(SEPARATOR)
+      return result
+    end
+  end
+end

--- a/app/lib/tomato_shrieker/shrieker/webhook_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/webhook_shrieker.rb
@@ -2,6 +2,29 @@ module TomatoShrieker
   class WebhookShrieker < SlackService
     include Package
 
+    # `/dest/hooks` の `type` と Shrieker の対応。
+    # ⚠ **クラスそのものではなく名前で持つ。** 定数の初期化はこのファイルの
+    # 読み込み時に走るので、クラスを直に書くと子クラスがまだ未定義で NameError
+    # になる（Zeitwerk の遅延ロードに任せる）。
+    CLASSES = {
+      'tsunagal' => 'TomatoShrieker::TsunagalWebhookShrieker',
+    }.freeze
+
+    # `/dest/hooks` の 1 要素から Shrieker を作る (#1493)。
+    #
+    # ⚠⚠ **`self.new` を差し替えてファクトリにしない。** 子クラスが継承した
+    # `new` から自分自身を作りに行き、無限再帰になる。呼び出し側は `create` を使う。
+    #
+    # ⚠ **種別は `type` キーの明示だけで決める。** `room_id` の有無のような
+    # 暗黙判定に頼らない。`channel` は Slack でも意味を持つので使えず、
+    # 「Matrix 固有なのは `room_id` だけ」という前提に乗ると、`channel` だけで
+    # 書かれた Tsunagal 宛（本番の 3 ソースがこの形）を取りこぼす。
+    def self.create(hook)
+      return new(hook) unless hook.is_a?(Hash)
+      name = CLASSES[hook.deep_symbolize_keys[:type].to_s]
+      return (name ? name.constantize : self).new(hook)
+    end
+
     def initialize(hook)
       case hook
       when Ginseng::URI
@@ -32,6 +55,14 @@ module TomatoShrieker
     end
 
     def create_body(body, type = :hash)
+      return build_body(body).to_json
+    end
+
+    # 送信する payload を Hash で組み立てる。⚠ **宛先ごとの差は `create_body`
+    # ではなくここを override して出す (#1493)。** `create_body` を丸ごと
+    # 差し替えると、下の `body[:template][:tag] = true` を落としやすい
+    # （#1484 が前提にしている）。
+    def build_body(body)
       body = body.clone
       body[:template][:tag] = true
       body[:text] = body[:template].to_s.strip
@@ -41,7 +72,7 @@ module TomatoShrieker
       body[:channel] ||= channel if channel
       body[:room_id] ||= room_id if room_id
       body.delete(:template)
-      return body.to_json
+      return body
     end
   end
 end

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -146,7 +146,8 @@ module TomatoShrieker
       yield piefed if piefed?
       yield nostr if nostr?
       (self['/dest/hooks'] || []).each do |hook|
-        yield WebhookShrieker.new(hook)
+        # ⚠ `new` ではなく `create`。hook の `type` で Shrieker を選ぶ (#1493)。
+        yield WebhookShrieker.create(hook)
       end
     end
 

--- a/app/lib/tomato_shrieker/template.rb
+++ b/app/lib/tomato_shrieker/template.rb
@@ -5,6 +5,11 @@ module TomatoShrieker
     # Source#templates は Template をインスタンスに memo 化するので、複製しないと
     # Parallel.each の各スレッドが同じ params を上書きし合う (#1474)。
     # @erb / @path は読み取り専用なので共有したままでよい。
+    #
+    # ⚠ **@params の複製は 1 段（浅コピー）** (#1490)。`Ginseng::Template#[]=` が
+    # `value.is_a?(Hash) ? value.deep_symbolize_keys : value` で**スロットごと
+    # 差し替える**前提に乗っている。⚠ **Hash 以外の可変値（Array 等）を params に
+    # 入れると共有に戻る**ので、そのときは別途複製が要る。
     def initialize_copy(original)
       super
       @params = original.params.dup

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -47,7 +47,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.6.1
+  version: 4.7.0
 nostr:
   relays:
     - wss://relay.damus.io

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -39,6 +39,14 @@ logger:
     - password
     - secret
     - auth
+  # ⚠ URL の**パス**が資格情報になっている宛先 (pooza/ginseng-core#580)。
+  # モロヘイヤの webhook は POST /mulukhiya/webhook/{digest} で、digest を知って
+  # いれば誰でもそのアカウントで投稿できる。接頭辞の次の 1 セグメントを落とす。
+  #
+  # ⚠ ginseng-core の既定にも同じ値が入っているので、ここは「本アプリが何を
+  # 秘密とみなしているか」を明示するためのもの。既定に頼らず書いておく。
+  mask_url_paths:
+    - /mulukhiya/webhook/
 package:
   authors:
     - Tatsuya Koishi

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -220,6 +220,13 @@ properties:
                 url:
                   type: string
                   format: uri
+                # 宛先の種別 (#1493)。省略すると Slack 互換の素の Webhook 扱い。
+                # ⚠ room_id の有無のような暗黙判定はしないので、Tsunagal 宛は
+                # 明示すること。書かないと CW (spoiler_text) が黙って落ちる。
+                type:
+                  type: string
+                  enum:
+                    - tsunagal
                 channel:
                   type: string
                 room_id:

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -24,12 +24,18 @@ anyOf:
   - properties:
       dest:
         anyOf:
-          - required: [hooks]
-          - required: [mastodon]
-          - required: [misskey]
-          - required: [line]
-          - required: [piefed]
-          - required: [nostr]
+          - required:
+              - hooks
+          - required:
+              - mastodon
+          - required:
+              - misskey
+          - required:
+              - line
+          - required:
+              - piefed
+          - required:
+              - nostr
 properties:
   disable:
     type: boolean

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -714,7 +714,7 @@ Nostr 対応は外部ユーザーのリクエストで実装された機能。�
 - `$TOKEN` は `~/.sentryclirc` の `[auth]` セクションから取得する
 - Sentry 未導入のプロジェクトではこのステップをスキップする
 
-### 6. 外部リポジトリの同期確認
+### 6. 外部リポジトリ・外部システムの同期確認
 
 #### ginseng-* のピン棚卸し
 
@@ -736,6 +736,21 @@ done
 遅れがあれば `bundle update <gem>` で追随する。⚠ **ルーチンの `Gemfile.lock` 最新化は PR 不要・`develop` 直コミットでよい**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。ただし**溜めてから一気に追随するときは単独 PR にして、本番で挙動を観察する**。
 
 ⚠ **追随で「必須の設定キー」が増えていることがある。**実例: ginseng-core 1.19.0 の `HTTP#initialize` は `/http/timeout/seconds` を読み、`/http/retry/max_seconds` と違って**既定へ倒れない**。無いと HTTP を作った時点で `ConfigError` になる（本体・サテライトとも `30` を設定済み）。**必ずローカルで `rake test` を通してから push する。**
+
+#### Kuma のモニターと有効ソースの突き合わせ
+
+🔴 **毎回実行する。**総合 `/healthz` は `undelivered` / `silent` を見ないので（#1508）、**Kuma に登録されていないソースは、配信が止まっていても誰も気づかない**。⚠ **登録は UI での手作業で自動化が無い**ため、ソースを足すたびに漏れうる。2026-08-21 時点で **有効 39 に対しモニター 24＝15 ソースが不可視**だった。
+
+```sh
+diff <(ssh oscura 'curl -s http://127.0.0.1:4567/status.json' | jq -r '.sources[].id' | sort) \
+     <(ssh mucor 'sudo docker exec uptime-kuma sqlite3 -readonly /app/data/kuma.db \
+        "select name from monitor where name like \"tomato-shrieker %\";"' | sed 's/^tomato-shrieker //' | sort)
+```
+
+- `<` の行 ＝ **Kuma に登録されていないソース**
+- `>` の行 ＝ **Kuma にあるが本番に無いソース**（消したソースのモニターが残っている）
+
+⚠ **機械的に全部足すのが正解とは限らない。**モニターが増えると Kuma 側（SQLite の単一ライタ）が詰まるので、[chubo2 の infra-note](https://github.com/pooza/chubo2/blob/main/docs/infra-note.md) のチェック間隔ティア分けに沿って、**赤で気づきたいものを選んで足す**。
 
 #### 上流への差し戻し
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -739,10 +739,13 @@ Nostr 対応は外部ユーザーのリクエストで実装された機能。�
 
 ⚠ **サテライト 3 本（`loquat` / `shooby-do-bop` / `dqdai-anniv`）も対象。**本体だけ追随すると CommandSource の 7 ソースだけ古い gem で動き続ける。
 
+🔴 **作業ツリーの `Gemfile.lock` を読んではいけない。**チェックアウトが古い feature ブランチに乗っていると、**そのブランチのピンを現状と誤読する**。2026-08-25 の sync では、サテライト 3 本が `chore/*-ginseng-style` に乗っていたせいで **ahead=103（実際は 21）** と出て、追随済みのものを未追随と誤判定しかけた。**必ず `origin/HEAD` から取り出す。**
+
 ```sh
 for d in tomato-shrieker loquat shooby-do-bop dqdai-anniv; do
-  awk '/github\.com\/pooza\/ginseng-/{g=$2; sub(/.*\//,"",g); sub(/\.git/,"",g); f=1} f&&/revision:/{print g, $2; f=0}' \
-    ~/repos/$d/Gemfile.lock |
+  git -C ~/repos/$d fetch -q origin
+  git -C ~/repos/$d show origin/HEAD:Gemfile.lock |
+  awk '/github\.com\/pooza\/ginseng-/{g=$2; sub(/.*\//,"",g); sub(/\.git/,"",g); f=1} f&&/revision:/{print g, $2; f=0}' |
   while read -r gem rev; do
     ahead=$(gh api repos/pooza/$gem/compare/$rev...main --jq .ahead_by 2>/dev/null)
     printf '%-16s %-18s %s\n' "$d" "$gem" "${ahead:-?}"
@@ -753,6 +756,24 @@ done
 遅れがあれば `bundle update <gem>` で追随する。⚠ **ルーチンの `Gemfile.lock` 最新化は PR 不要・`develop` 直コミットでよい**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。ただし**溜めてから一気に追随するときは単独 PR にして、本番で挙動を観察する**。
 
 ⚠ **追随で「必須の設定キー」が増えていることがある。**実例: ginseng-core 1.19.0 の `HTTP#initialize` は `/http/timeout/seconds` を読み、`/http/retry/max_seconds` と違って**既定へ倒れない**。無いと HTTP を作った時点で `ConfigError` になる（本体・サテライトとも `30` を設定済み）。**必ずローカルで `rake test` を通してから push する。**
+
+#### サテライト 3 本の open PR / issue と CI
+
+🔴 **毎回実行する。**`loquat` / `shooby-do-bop` / `dqdai-anniv` は **CommandSource の 7 ソースの実体**だが、tomato 側からは見えないので**放置されても誰も気づかない**。⚠ **上流（`ginseng-style` / `ginseng-*`）はこちらへ PR / Issue を送ってくるので、受け取りが止まると横断の変更がここで詰まる。**
+
+```sh
+for d in loquat shooby-do-bop dqdai-anniv; do
+  b=$(gh repo view pooza/$d --json defaultBranchRef --jq .defaultBranchRef.name)
+  echo "=== $d ($b) ==="
+  gh pr list -R pooza/$d --state open
+  gh issue list -R pooza/$d --state open
+  gh run list -R pooza/$d -b $b -L 1 --json conclusion,headSha --jq '.[]|"CI \(.conclusion) \(.headSha[0:7])"'
+done
+```
+
+🔴 **2026-08-25 の実測では 3 本とも default ブランチの CI が赤で、上流からの PR が 6 日間止まっていた。**⚠ **`dqdai-anniv` は TZ 依存のバグ（[#32](https://github.com/pooza/dqdai-anniv/issues/32)）で 4 日以上赤のまま**で、それが上流の PR まで巻き添えにしていた。
+
+⚠ **上流から届いた PR がブランチを切った時点より default が進んでいることがある。**`chore/*-ginseng-style` は `/http/timeout/seconds` の設定より前から出ていたので、**そのままでは CI が `ConfigError` で落ちる**。**default をマージしてから通す。**
 
 #### Kuma のモニターと有効ソースの突き合わせ
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -178,6 +178,7 @@ ssh oscura 'sudo systemctl restart tomato-shrieker'
 
 ### 本番操作の注意
 
+- ⚠ **本番のチェックアウトを `git` で覗くときは必ず `deploy` ユーザーで。**`ssh oscura 'git -C ~deploy/repos/tomato-shrieker log'` は `detected dubious ownership` で落ちる。`sudo -iu deploy bash -lc "cd ~/repos/tomato-shrieker && git log"` と書く（`sudo -u deploy` では rbenv が効かず system ruby になるので `-i` が要る）
 - 本番デーモンは必ず OS のサービス管理経由 (`systemctl restart tomato-shrieker` / `service tomato_shrieker restart` 等) で操作する。SSH ワンライナーで `scheduler_daemon.rb start` を直接呼ぶとセッション切断時にプロセスが死ぬ（v3.9.10 インシデントの教訓）
 - Monit を停止/再開する際は事前にユーザーに確認する
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -716,6 +716,31 @@ Nostr 対応は外部ユーザーのリクエストで実装された機能。�
 
 ### 6. 外部リポジトリの同期確認
 
+#### ginseng-* のピン棚卸し
+
+🔴 **毎回必ず実行する。**`Gemfile.lock` は git 参照のリビジョンを固定するので、**放っておくと何ヶ月も進まず、security 修正だけが届かない状態になる**。2026-08-21 の sync では `ginseng-core` が **82 コミット遅れ**（1.15.28 → 1.19.0）で、SSRF 対策・ログの資格情報スクラブが丸ごと未達だった。⚠ **この手順が空だったことが原因**。
+
+⚠ **サテライト 3 本（`loquat` / `shooby-do-bop` / `dqdai-anniv`）も対象。**本体だけ追随すると CommandSource の 7 ソースだけ古い gem で動き続ける。
+
+```sh
+for d in tomato-shrieker loquat shooby-do-bop dqdai-anniv; do
+  awk '/github\.com\/pooza\/ginseng-/{g=$2; sub(/.*\//,"",g); sub(/\.git/,"",g); f=1} f&&/revision:/{print g, $2; f=0}' \
+    ~/repos/$d/Gemfile.lock |
+  while read -r gem rev; do
+    ahead=$(gh api repos/pooza/$gem/compare/$rev...main --jq .ahead_by 2>/dev/null)
+    printf '%-16s %-18s %s\n' "$d" "$gem" "${ahead:-?}"
+  done
+done
+```
+
+遅れがあれば `bundle update <gem>` で追随する。⚠ **ルーチンの `Gemfile.lock` 最新化は PR 不要・`develop` 直コミットでよい**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。ただし**溜めてから一気に追随するときは単独 PR にして、本番で挙動を観察する**。
+
+⚠ **追随で「必須の設定キー」が増えていることがある。**実例: ginseng-core 1.19.0 の `HTTP#initialize` は `/http/timeout/seconds` を読み、`/http/retry/max_seconds` と違って**既定へ倒れない**。無いと HTTP を作った時点で `ConfigError` になる（本体・サテライトとも `30` を設定済み）。**必ずローカルで `rake test` を通してから push する。**
+
+#### 上流への差し戻し
+
+⚠ **アプリ側で回避策を持たない。**gem を直せば済むと分かったら、**該当 gem のリポジトリに Issue を立てる**。横断の話（RuboCop 設定・規約・CI）は [pooza/ginseng-style](https://github.com/pooza/ginseng-style) へ。ginseng-* は自走しており、Issue / PR は埋もれない。
+
 > **TODO**: chubo2 インフラノート（`pooza/chubo2` の `docs/infra-note.md`）との連携が整ったタイミングで手順を追加する。
 
 ### 7. マイルストーンの状態確認

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -11,9 +11,11 @@
 
 ## ブランチ戦略
 
+⚠ **Issue 駆動・ブランチ命名（`fix/<issue>-<slug>`）・`gh pr create --base` の明示は [ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) が正本。**ここに書き写さない。
+
 | ブランチ | 目的 |
 | --- | --- |
-| `main` | リリース済み安定版（デフォルト） |
+| `main` | リリース済み安定版（デフォルト）。**本番のデプロイ対象**＝ここへマージするのは必ずリリース |
 | `develop` | 開発ブランチ。日常の作業はここで行う |
 
 ### リリースフロー
@@ -67,11 +69,9 @@ gh issue list --state open --limit 60 --json number,milestone,labels \
 
 対象範囲は `v<前リリース>..develop` の差分。Codex（`chatgpt-codex-connector[bot]`）は PR ready 時に走るので併走させ、重複しない指摘だけを拾う。
 
-指摘は以下の基準で分類し、必要最小限のみ本リリースで対応、残りは Issue 起票して次リリース以降に送る:
+⚠ **指摘の分類（赤＝必修 / 黄＝余力があれば / 緑＝送り）とその扱いは [workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) が正本。**必要最小限のみ本リリースで対応し、残りは Issue 起票して次リリース以降へ送る。
 
-- **赤（必修）**: データ破損・セキュリティ・ユーザー可視の機能不全
-- **黄（余力があれば）**: 単一の edge case、観測性ギャップ
-- **緑（送り）**: 将来の拡張時に顕在化しうる構造改善
+⚠ **上の 5 観点のうち共通なのは「セキュリティ」「エラー処理・観測性」「コーディングスタイル・規約整合性」の 3 つ**で、正本にも同じものがある。**「設定・宛先契約」「スケジューラ・ライフサイクル」が tomato 固有**の観点。
 
 ### リリースノート
 
@@ -790,8 +790,9 @@ diff <(ssh oscura 'curl -s http://127.0.0.1:4567/status.json' | jq -r '.sources[
 
 ## 情報の記載先ルール
 
-- **課題・タスク** → GitHub Issue で管理
-- **プロジェクト共有すべき知見** → `docs/CLAUDE.md` など git 管理下のファイルに記載
+⚠ **「課題・タスクは Issue で管理する」「docs に書くだけでは管理されていない扱い」は [workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) が正本。**tomato 固有はこの 2 つ。
+
+- **プロジェクト共有すべき知見** → `docs/CLAUDE.md` など git 管理下のファイルに記載する。⚠ **メモリにだけ置かない**
 - **進捗の同期** → `MEMORY.md` だけでなく `docs/CLAUDE.md` も更新すること。特にリリース済みバージョンの反映（「開発中」→「リリース済み」への変更）を忘れないこと
 
 ## 関連リポジトリ

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -36,6 +36,23 @@
 | マイグレーション・デプロイ順序・移行作業 | アップデート手順 |
 | ソース種別・投稿先・スケジュール | 各ソース／Shrieker のページ |
 
+### マイルストーンのサイズ
+
+⚠ **正本は [ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)。**ここには tomato での運用だけ書く。
+
+- `size:S`（重み 1・50 行未満）/ `size:M`（3・50〜200 行）/ `size:L`（8・200 行超）を**全 Issue に付ける**。2026-08-21 に open 全件へ遡及付与した
+- **1 マイルストーンの目安は 20〜25 重み。**超えたら Issue を次のマイナーへ送る
+- ⚠ **大物（`size:L`）は 1 マイルストーンに 1 件まで**
+
+重みの合計はこれで出せる。
+
+```sh
+gh issue list --state open --limit 60 --json number,milestone,labels \
+  --jq '.[] | "\(.milestone.title // "未割当") \(.labels | map(.name) | map(select(startswith("size:"))) | join(""))"' \
+  | awk '{w = $2=="size:S" ? 1 : $2=="size:M" ? 3 : $2=="size:L" ? 8 : 0; n[$1]++; c[$1]+=w} \
+         END {for (k in c) printf "%s: %d 件 / 重み %d\n", k, n[k], c[k]}' | sort
+```
+
 ### リリース前レビュー
 
 各マイルストーンの Issue が消化済みになった後、バージョンバンプに入る前に実施する。**単一のセキュリティレビューだけでは実用上の問題が取りこぼされる**ため、以下 5 観点を独立したサブエージェントで並列に走らせ、指摘を合流させる（モロヘイヤ／capsicum で先行運用しているプラクティスの移植）。

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -540,22 +540,33 @@ dest:
   hooks:
     - https://example.com/hook          # 従来どおりの URL 指定
     - url: https://example.com/webhook  # matrix-webhook 宛
+      type: tsunagal
       channel: '#alerts:example.com'    # ルームエイリアス
     - url: https://example.com/webhook
+      type: tsunagal
       room_id: '!AbCdEf:example.com'    # ルーム ID（channel との択一）
 ```
 
 | キー | 必須 | 内容 |
 |------|------|------|
 | `url` | 必須 | 送信先 Webhook URL |
+| `type` | 任意 | 宛先の種別。`tsunagal` のみ。省略すると Slack 互換の素の Webhook 扱い |
 | `channel` | 任意 | ルームエイリアス（`#name:server` 形式） |
 | `room_id` | 任意 | ルーム ID（`!xxxx:server` 形式） |
 
-⚠ **スキーマが `additionalProperties: false` なので、この 3 つ以外のキーは書けない。**`config/schema/source.yaml` の `hooks` を参照。
+⚠ **スキーマが `additionalProperties: false` なので、この 4 つ以外のキーは書けない。**`config/schema/source.yaml` の `hooks` を参照。
 
 ⚠ **`channel` / `room_id` は matrix-webhook 側の解釈**で、`WebhookShrieker` はペイロードに載せるだけ。Slack / Discord / モロヘイヤ宛に書いても無視される。
 
-⚠ **Matrix 宛では CW（`spoiler_text`）が表示されない (#1493)。**matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ないため、テンプレートに CW があっても**エラーにならずに内容が落ちる**。同じソースをモロヘイヤと matrix-webhook の両方へ流すと Matrix 宛だけ情報が欠ける。
+##### `type: tsunagal` — Tsunagal（matrix-webhook）宛 (#1493)
+
+🔴 **matrix-webhook は `text` / `channel` / `room_id` / `format` しか見ない。**未知のフィールドは黙って無視されるので、`WebhookShrieker` が積む `spoiler_text` は**エラーにもならずに落ちていた**。同じソースをモロヘイヤと matrix-webhook の両方へ流すと、**Matrix 宛だけ CW の内容が消える。**
+
+`type: tsunagal` を書くと `TsunagalWebhookShrieker` が選ばれ、**CW を本文の先頭へ畳んで送る**（`spoiler_text` ＋ 空行 ＋ 本文）。⚠ **Matrix に CW の標準は無い**ので、これは独自の見せ方。
+
+⚠⚠ **`type` を書かないと従来どおり CW は落ちる。**`room_id` の有無のような暗黙判定は**しない** — `channel` は Slack でも意味を持つので判定に使えず、「Matrix 固有なのは `room_id` だけ」という前提に乗ると、**`channel` だけで書かれた宛先（本番の 3 ソースがこの形）を取りこぼす**。
+
+⚠ **クラス名が `Matrix～` でないのは意図的。**喋る相手は Matrix の Client-Server API ではなく `tsunagal/matrix-webhook` という HTTP webhook なので、`MatrixShrieker` は将来 C-S API を実装するときのために空けてある。
 
 ### モロヘイヤ連携
 

--- a/docs/release-validation.md
+++ b/docs/release-validation.md
@@ -181,17 +181,20 @@ curl -sS "https://pf.korako.me/api/alpha/post/list?community_id=82&sort=New&limi
 
 ⚠ **`curl` や Python の urllib で `/api/alpha/user/login` を直接叩いて確かめようとしないこと。**Cloudflare が弾いて **HTTP 403 (error code 1010)** を返し、認証失敗と見分けが付かない。必ず下記のようにアプリの HTTP クライアント経由で確認する（2026-08-03 に踏んだ）。なお `/api/alpha/post/list` のような GET は `curl` でも通る。
 
+⚠ **4.7.0 (#1514) から login は遅延する。**構築しただけでは `@jwt` は `absent` のままなので、**明示的に `login` を呼んでから見る**こと。
+
 ```sh
 bundle exec ruby -Iapp/lib -rtomato_shrieker -e '
 include TomatoShrieker
 Sequel.connect(Environment.dsn)
 src = Source.create("test-google-news-piefed")
 shr = src.piefed
+shr.login
 puts "JWT: #{shr.instance_variable_get(:@jwt) ? "present" : "absent"}"
 '
 ```
 
-JWT が `present` なら login 成功。`absent` なら認証情報が古い等の可能性。
+JWT が `present` なら login 成功。`Ginseng::AuthError` が上がるなら認証情報が古い等の可能性。
 
 ## チェックリスト
 

--- a/test/config.rb
+++ b/test/config.rb
@@ -1,11 +1,75 @@
 module TomatoShrieker
-  class ConfigText < TestCase
-    def load
-      config.load
+  class ConfigTest < TestCase
+    # ⚠ 実在のソースと衝突しない接頭辞。後始末に失敗しても見分けがつくようにする。
+    PREFIX = '__test_config_atomic__'.freeze
+
+    def teardown
+      cleanup
+      super
     end
 
     def test_secure_dump
       assert_kind_of(Array, config.secure_dump)
+    end
+
+    # #1530: reload の途中経過が外から見えないこと。
+    #
+    # 🔴 以前は `self['/sources']` へ 1 件ずつ push していたので、push の間だけ
+    # 一覧が短かった。⚠ `/status.json` は全ソースを舐めるので約 900ms かかり
+    # (#1472)、この窓に重なると**ソースが欠けて見える**。`/healthz/source/:id` は
+    # 404 を返し、Kuma に偽の 404 / 503 が出る。
+    def test_load_never_exposes_partial_sources
+      write_sources(5)
+      config.reload
+      expected = config['/sources'].size
+      observed = []
+      reader = Thread.new do
+        observed.push(config['/sources'].size) while Thread.current[:run] != false
+      end
+      reader[:run] = true
+      10.times {config.reload}
+      reader[:run] = false
+      reader.join(5)
+
+      assert_operator(observed.size, :>, 0, '読み手が 1 度も観測できていない')
+      assert_equal([expected], observed.uniq, "reload の途中経過が見えている: #{observed.uniq.sort}")
+    end
+
+    # 🔴 #1530: 壊れた YAML があっても、それまでの内容を壊さないこと。
+    #
+    # 以前は 3 件目で raise すると 2 件目まで積まれた状態で残った。⚠ ソース定義を
+    # 手で 1 文字打ち間違えただけで、稼働中のソース一覧が壊れた。
+    def test_load_keeps_previous_sources_when_yaml_is_broken
+      write_sources(3)
+      config.reload
+      before = config['/sources'].size
+
+      File.write(source_path('broken'), "source:\n  feed: [unclosed\n")
+
+      assert_raise_kind_of(StandardError) {config.reload}
+      assert_equal(before, config['/sources'].size, '壊れた YAML で一覧が欠けている')
+    end
+
+    private
+
+    def write_sources(count)
+      count.times do |i|
+        File.write(source_path(i), {
+          'source' => {'text' => "test #{i}"},
+          'schedule' => {'cron' => '0 0 * * *'},
+          'dest' => {'tags' => ['test']},
+        }.to_yaml)
+      end
+    end
+
+    def source_path(key)
+      return File.join(Environment.dir, 'config/sources', "#{PREFIX}#{key}.yaml")
+    end
+
+    def cleanup
+      Dir.glob(File.join(Environment.dir, 'config/sources', "#{PREFIX}*")).each do |f|
+        File.delete(f)
+      end
     end
   end
 end

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -260,6 +260,25 @@ module TomatoShrieker
       assert_kind_of(Array, payload['sources'])
     end
 
+    # #1471: ランタイムの能力欠落を検知できるようにする。
+    #
+    # 🔴 YJIT は Rust の無い環境ではビルド時に黙って外れ、エラーにならないまま
+    # 24〜25% 遅いサーバーが出来上がる。⚠ **後者になっても誰も気づけない**ので、
+    # Kuma がキーワード監視で見られる形に出す。
+    def test_status_json_reports_ruby_runtime
+      _status, _headers, body = call('/status.json')
+      ruby = JSON.parse(body.first)['ruby']
+
+      assert_kind_of(Hash, ruby)
+      assert_equal(RUBY_VERSION, ruby['version'])
+      # ⚠ Ginseng::Environment.jit? は真のとき "constant"（String）を返す。
+      # JSON へ素で載せると boolean にならないので、真偽に倒れていることを見る。
+      assert_boolean(ruby['yjit_available'])
+      assert_boolean(ruby['yjit_enabled'])
+      # 積まれていなければ有効にはなりえない
+      assert_true(ruby['yjit_available']) if ruby['yjit_enabled']
+    end
+
     # #1433 / #1457 / #1470 で足した指標が全ソース分そろっていること
     def test_status_json_delivery_fields
       _status, _headers, body = call('/status.json')

--- a/test/package.rb
+++ b/test/package.rb
@@ -54,6 +54,25 @@ module TomatoShrieker
       assert_include(message, 'vjump-youtube')
     end
 
+    # ⚠⚠ マスクに失敗したときのフォールバックが、名前空間付きのクラス名で
+    # 壊れないこと。`':'` で切ると `Ginseng::GatewayError` が `Ginseng` になる。
+    # tomato の例外はほぼ全部 `Ginseng::` 配下なので実質いつも壊れていた。
+    def test_error_class_of
+      assert_equal(
+        'Ginseng::GatewayError',
+        Package.error_class_of('Ginseng::GatewayError: Bad response 404 (https://x/y)'),
+      )
+      assert_equal('RuntimeError', Package.error_class_of('RuntimeError: boom'))
+    end
+
+    # 🔴 区切りが無い文字列を丸ごと返さないこと。素通しにすると、マスクに失敗した
+    # 本文がそのまま出る。
+    def test_error_class_of_does_not_pass_through
+      message = 'https://precure.ml/mulukhiya/webhook/SECRET'
+
+      assert_not_include(Package.error_class_of(message), 'SECRET')
+    end
+
     # ⚠ 不正なバイト列でもマスクごと素通りしないこと (#518 / #1469 の族)。
     # to_utf8 の後にマスクを通しているかを見る。
     def test_error_message_masks_broken_bytes

--- a/test/package.rb
+++ b/test/package.rb
@@ -1,0 +1,70 @@
+module TomatoShrieker
+  class PackageTest < TestCase
+    # 🔴 例外メッセージに埋まった資格情報が落ちること (#1511)。
+    #
+    # ⚠ Package.error_message は **source_run_log.error_message の唯一の入口**で、
+    # かつ /healthz/source の 503 本文にも使われる。ここを通った文字列は
+    # /status.json からそのまま読める。本番の monitor.bind は 0.0.0.0 なので
+    # LAN / VPN の誰からでも見える (#1531)。
+    WEBHOOK_DIGEST = 'fa9c541e163ff35ac49e12dd5ad71dc4e27876a3a5514f46d074e9b6f190652d'.freeze
+
+    def test_error_message
+      assert_nil(Package.error_message(nil))
+      assert_equal(
+        'Ginseng::GatewayError: Bad response 404',
+        Package.error_message(Ginseng::GatewayError.new('Bad response 404')),
+      )
+    end
+
+    # WebhookShrieker の失敗はこの形になる。digest を知っていれば誰でも投稿できる。
+    def test_error_message_masks_webhook_digest
+      error = Ginseng::GatewayError.new(
+        "Bad response 404 (https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST})",
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, WEBHOOK_DIGEST)
+      assert_include(message, '[FILTERED]')
+      assert_include(message, 'Bad response 404', '診断に要る情報は残す')
+    end
+
+    # FeedSource#feedjira は URI を丸ごとメッセージへ埋める。認証付きフィードを
+    # 足した時点で、そのまま run_log へ保存される。
+    def test_error_message_masks_feed_token
+      error = Ginseng::GatewayError.new(
+        'Invalid feed x (https://example.com/feed.xml?access_token=TOKENVALUE) Bad response 500',
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, 'TOKENVALUE')
+      assert_include(message, 'Bad response 500')
+    end
+
+    # ⚠ 資格情報を含まない URL は残すこと。消すとどのフィードが壊れたのか判らない。
+    def test_error_message_keeps_harmless_url
+      error = Ginseng::GatewayError.new(
+        'Invalid feed vjump-youtube (https://www.youtube.com/feeds/videos.xml?channel_id=UCTwO5UAGiB8AdFrsxhNKaRQ) Bad response 404',
+      )
+
+      message = Package.error_message(error)
+
+      assert_include(message, 'UCTwO5UAGiB8AdFrsxhNKaRQ')
+      assert_include(message, 'vjump-youtube')
+    end
+
+    # ⚠ 不正なバイト列でもマスクごと素通りしないこと (#518 / #1469 の族)。
+    # to_utf8 の後にマスクを通しているかを見る。
+    def test_error_message_masks_broken_bytes
+      error = Ginseng::GatewayError.new(
+        "\xE3\x81 (https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST})",
+      )
+
+      message = Package.error_message(error)
+
+      assert_not_include(message, WEBHOOK_DIGEST)
+      assert_true(message.valid_encoding?)
+    end
+  end
+end

--- a/test/piefed_shrieker.rb
+++ b/test/piefed_shrieker.rb
@@ -20,3 +20,56 @@ module TomatoShrieker
     end
   end
 end
+
+module TomatoShrieker
+  # ⚠ 上の PiefedShriekerTest は dest に piefed を持つテスト用ソースが手元に無いと
+  # `disable?` で丸ごと落ちる (#1520)。login の遅延だけは環境に依らず見たいので、
+  # webmock で閉じた独立のテストケースにする。
+  class PiefedShriekerLoginTest < TestCase
+    PARAMS = {
+      host: 'piefed.example.com',
+      user_id: 'user@example.com',
+      password: 'password',
+      community_id: 1,
+    }.freeze
+
+    def setup
+      WebMock.enable!
+      WebMock.disable_net_connect!
+      @stub = stub_request(:post, %r{/user/login}).to_return(
+        status: 200,
+        body: '{"jwt":"dummy"}',
+        headers: {'Content-Type' => 'application/json'},
+      )
+    end
+
+    def teardown
+      WebMock.allow_net_connect!
+      WebMock.disable!
+      super
+    end
+
+    # #1514: 構築時に無条件で login すると、投稿しないケース（設定の読み込み・
+    # source list・テストの初期化）でも認証 API を叩き、429 を踏みやすくなる。
+    def test_does_not_login_on_initialize
+      PiefedShrieker.new(PARAMS)
+
+      assert_not_requested(@stub)
+    end
+
+    def test_logs_in_on_demand
+      shrieker = PiefedShrieker.new(PARAMS)
+      shrieker.login
+
+      assert_requested(@stub, times: 1)
+    end
+
+    # ⚠ 上流の Service#login は `return if @jwt` を持つ。exec のたびに叩き直さない。
+    def test_does_not_login_twice
+      shrieker = PiefedShrieker.new(PARAMS)
+      2.times {shrieker.login}
+
+      assert_requested(@stub, times: 1)
+    end
+  end
+end

--- a/test/sentry_scrubber.rb
+++ b/test/sentry_scrubber.rb
@@ -71,6 +71,32 @@ module TomatoShrieker
       assert_nil(@scrubber.scrub(event))
     end
 
+    # 🔴 **落としたことをログに残すこと。** `warn` は本番で `/dev/null`
+    # （scheduler_daemon が stderr を潰す）なので、そこへ出すと「Sentry へ何も
+    # 届かないのに誰も気づけない」になる。
+    def test_scrub_logs_when_event_is_dropped
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+      logged = []
+      @scrubber.instance_variable_get(:@logger).define_singleton_method(:error) do |arg|
+        logged.push(arg)
+      end
+
+      @scrubber.scrub(event)
+
+      assert_equal(1, logged.size, 'イベントを黙って捨てている')
+      assert_equal('before_send', logged.first[:sentry])
+    end
+
+    # ⚠ ログ自体が落ちても before_send を巻き込まないこと。
+    def test_scrub_survives_logger_failure
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+      @scrubber.instance_variable_get(:@logger).define_singleton_method(:error) {|_arg| raise 'logger boom'}
+
+      assert_nothing_raised {assert_nil(@scrubber.scrub(event))}
+    end
+
     private
 
     def error_event(error)

--- a/test/sentry_scrubber.rb
+++ b/test/sentry_scrubber.rb
@@ -1,0 +1,94 @@
+module TomatoShrieker
+  # Sentry へ送るペイロードから資格情報が落ちていること (#1467)。
+  #
+  # ⚠⚠ **「マスク処理を呼んでいる」ではなく「出力に含まれていない」を見る。**
+  # 呼んでいるかどうかは、対象の列がズレていれば通ってしまう。
+  class SentryScrubberTest < TestCase
+    # モロヘイヤの webhook は POST /mulukhiya/webhook/{digest} で、**パスその
+    # ものが資格情報**。digest を知っていれば誰でもそのアカウントで投稿できる。
+    WEBHOOK_DIGEST = 'fa9c541e163ff35ac49e12dd5ad71dc4e27876a3a5514f46d074e9b6f190652d'.freeze
+    WEBHOOK_URL = "https://precure.ml/mulukhiya/webhook/#{WEBHOOK_DIGEST}".freeze
+    FEED_TOKEN = 'SUPERSECRETTOKEN'.freeze
+    FEED_URL = "https://example.com/feed.xml?access_token=#{FEED_TOKEN}".freeze
+
+    def setup
+      @scrubber = SentryScrubber.new
+    end
+
+    def test_new
+      assert_kind_of(SentryScrubber, @scrubber)
+    end
+
+    # 🔴 tomato でいちばん漏れる経路。WebhookShrieker の失敗は
+    # Ginseng::GatewayError になり、メッセージに URI が丸ごと載る。
+    def test_scrub_exception_message
+      event = error_event(Ginseng::GatewayError.new("Bad response 404 (#{WEBHOOK_URL})"))
+
+      scrubbed = @scrubber.scrub(event)
+
+      assert_not_nil(scrubbed, 'イベントを落としてはいけない')
+      assert_not_include(payload(scrubbed), WEBHOOK_DIGEST)
+      assert_include(payload(scrubbed), '[FILTERED]')
+    end
+
+    # FeedSource#feedjira は URI を丸ごとメッセージへ埋める。認証付きフィードを
+    # 足した時点で、そのまま Sentry へ出る。
+    def test_scrub_exception_message_query_credentials
+      event = error_event(Ginseng::GatewayError.new("Invalid feed x (#{FEED_URL})"))
+
+      assert_not_include(payload(@scrubber.scrub(event)), FEED_TOKEN)
+    end
+
+    # extra / tags は自分で積む場所なので、mask_fields のキーごと落ちること。
+    def test_scrub_extra_and_tags
+      event = error_event(StandardError.new('boom'))
+      event.extra = {password: 'PLAINTEXT', url: WEBHOOK_URL, source: 'shooby'}
+      event.tags = {secret: 'PLAINTEXT'}
+
+      scrubbed = payload(@scrubber.scrub(event))
+
+      assert_not_include(scrubbed, 'PLAINTEXT')
+      assert_not_include(scrubbed, WEBHOOK_DIGEST)
+      assert_include(scrubbed, 'shooby', '無関係な値は残す')
+    end
+
+    # ⚠ 資格情報を含まない情報まで消してはいけない。消すと調査に使えなくなる。
+    def test_scrub_keeps_diagnostics
+      event = error_event(Ginseng::GatewayError.new('Invalid feed vjump-youtube (https://www.youtube.com/feeds/videos.xml?channel_id=UCTwO5UAGiB8AdFrsxhNKaRQ)'))
+
+      scrubbed = payload(@scrubber.scrub(event))
+
+      assert_include(scrubbed, 'vjump-youtube')
+      assert_include(scrubbed, 'UCTwO5UAGiB8AdFrsxhNKaRQ')
+    end
+
+    # 🔴 **fail closed。** マスクを通せなかったイベントは送らない。素通しで送ると
+    # 伏せるはずだった値がそのまま外部サービスへ出る。
+    def test_scrub_drops_event_when_mask_fails
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+
+      assert_nil(@scrubber.scrub(event))
+    end
+
+    private
+
+    def error_event(error)
+      client = Sentry::Client.new(sentry_configuration)
+      return client.event_from_exception(error)
+    end
+
+    def sentry_configuration
+      config = Sentry::Configuration.new
+      config.dsn = 'https://publickey@example.com/1'
+      config.environment = 'test'
+      return config
+    end
+
+    # ⚠ **実際に送られる形（シリアライズ後）で見る。** アクセサ越しに 1 つずつ
+    # 確かめると、見落とした欄がそのまま外へ出る。
+    def payload(event)
+      return event.to_json_compatible.to_json
+    end
+  end
+end

--- a/test/source_command.rb
+++ b/test/source_command.rb
@@ -1,0 +1,33 @@
+module TomatoShrieker
+  class SourceCommandTest < TestCase
+    def setup
+      @command = SourceCommand.new
+    end
+
+    # #1513: silence_tolerance の表示が整数除算で「0日」にならないこと。
+    #
+    # ⚠ スキーマは `12h` / `30m` を許すので (`^((\d+(\.\d+)?[smhdwMy])+|\d+(\.\d+)?)$`)、
+    # 日未満のソースでは「次に silence_tolerance (0日) を超えたら」と出ていた。
+    # ⚠ #1496 の「9 月上旬に 7d → 3d へ締める」運用で日未満を入れたら踏む。
+    def test_tolerance_label
+      {
+        7_776_000 => '90日',
+        259_200 => '3日',
+        129_600 => '36時間',
+        43_200 => '12時間',
+        1_800 => '30分',
+        45 => '45秒',
+      }.each do |seconds, expected|
+        assert_equal(expected, @command.send(:tolerance_label, stub_source(seconds)))
+      end
+    end
+
+    private
+
+    def stub_source(seconds)
+      source = Object.new
+      source.define_singleton_method(:monitor_silence_tolerance_seconds) {seconds}
+      return source
+    end
+  end
+end

--- a/test/source_run_log.rb
+++ b/test/source_run_log.rb
@@ -107,6 +107,42 @@ module TomatoShrieker
       assert_not_nil(SourceRunLog.last_delivered_at(SOURCE_ID))
     end
 
+    # 🔴 #1511: 保護行は retention_days を超えて無期限に残るので、そこに
+    # error_message が乗ったままだと「例外メッセージは N 日で消える」という
+    # 保持上限が保護行だけ外れる。⚠ 判定に使うのは executed_at /
+    # attempted_count / delivered_count だけなので、落としても保護は壊れない。
+    def test_prune_redacts_error_message_of_protected_rows
+      SourceRunLog.create(
+        source_id: SOURCE_ID, executed_at: Time.now - (20 * 86_400),
+        status: SourceRunLog::STATUS_PARTIAL, duration_ms: 10,
+        attempted_count: 2, delivered_count: 1,
+        error_message: 'Ginseng::GatewayError: Invalid feed x (https://example.com/f?access_token=TOKENVALUE)'
+      )
+      SourceRunLog.prune(14)
+      remain = SourceRunLog.where(source_id: SOURCE_ID).all
+
+      assert_equal(1, remain.size, '保護行そのものは残る')
+      assert_nil(remain.first.error_message)
+      assert_true(SourceRunLog.undelivered?(SOURCE_ID), '取りこぼしの判定は生きている')
+    end
+
+    # ⚠ 期限内の行の error_message は消さないこと。消すと直近の失敗理由が
+    # 読めなくなる。
+    def test_prune_keeps_error_message_within_retention
+      SourceRunLog.create(
+        source_id: SOURCE_ID, executed_at: Time.now - 3600,
+        status: SourceRunLog::STATUS_ERROR, duration_ms: 10,
+        attempted_count: 1, delivered_count: 0,
+        error_message: 'Ginseng::GatewayError: Bad response 404'
+      )
+      SourceRunLog.prune(14)
+
+      assert_equal(
+        'Ginseng::GatewayError: Bad response 404',
+        SourceRunLog.where(source_id: SOURCE_ID).first.error_message,
+      )
+    end
+
     # 🔴 #1504: 取りこぼしの根拠行を刈ると、赤くなったソースが retention_days の
     # 経過だけで黙って緑に戻る。「次に配信できたときだけ解除する」が壊れる。
     def test_prune_keeps_last_attempted_row

--- a/test/tsunagal_webhook_shrieker.rb
+++ b/test/tsunagal_webhook_shrieker.rb
@@ -1,0 +1,110 @@
+module TomatoShrieker
+  # #1493: matrix-webhook 宛で CW (spoiler_text) が黙って捨てられていた。
+  class TsunagalWebhookShriekerTest < TestCase
+    HOOK_URL = 'https://synapse.example.com/webhook'.freeze
+    SPOILER = 'ネタバレ注意'.freeze
+    TEXT = '本文です'.freeze
+
+    # ⚠ 種別は `type` の明示だけで決める。`room_id` の有無のような暗黙判定に
+    # 頼らない。`channel` は Slack でも意味を持つので判定に使えず、
+    # 「Matrix 固有なのは room_id だけ」という前提に乗ると、**channel だけで
+    # 書かれた宛先（本番の 3 ソースがこの形）を取りこぼす**。
+    def test_create_selects_by_type
+      assert_instance_of(
+        TsunagalWebhookShrieker,
+        WebhookShrieker.create('url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#x:example.com'),
+      )
+    end
+
+    def test_create_defaults_to_plain_webhook
+      assert_instance_of(WebhookShrieker, WebhookShrieker.create(HOOK_URL))
+      assert_instance_of(WebhookShrieker, WebhookShrieker.create('url' => HOOK_URL))
+      # ⚠ room_id があっても type が無ければ素の Webhook のまま
+      assert_instance_of(
+        WebhookShrieker,
+        WebhookShrieker.create('url' => HOOK_URL, 'room_id' => '!x:example.com'),
+      )
+    end
+
+    # 🔴 本題。matrix-webhook は text / channel / room_id / format しか見ないので、
+    # spoiler_text を積んでも黙って落ちる。本文の先頭へ畳んで送る。
+    def test_build_body_folds_spoiler_text_into_text
+      body = tsunagal.build_body(template: template(SPOILER))
+
+      assert_nil(body[:spoiler_text], 'matrix-webhook が見ないキーは送らない')
+      assert_include(body[:text], SPOILER)
+      assert_include(body[:text], TEXT)
+      assert_equal("#{SPOILER}\n\n#{TEXT}", body[:text])
+    end
+
+    # ⚠ CW が無いソースの本文を変えないこと。
+    def test_build_body_without_spoiler_text
+      assert_equal(TEXT, tsunagal.build_body(template: template(nil))[:text])
+    end
+
+    # 素の WebhookShrieker は従来どおり spoiler_text を別キーで送る
+    # （モロヘイヤは解釈できる）。
+    def test_plain_webhook_keeps_spoiler_text
+      body = WebhookShrieker.new(HOOK_URL).build_body(template: template(SPOILER))
+
+      assert_equal(SPOILER, body[:spoiler_text])
+      assert_equal(TEXT, body[:text])
+    end
+
+    # ⚠⚠ #1484 の前提。build_body を override するとき tag を落とさないこと。
+    def test_build_body_keeps_tag_flag
+      tmpl = template(SPOILER)
+      tsunagal.build_body(template: tmpl)
+
+      assert_true(tmpl[:tag])
+    end
+
+    # channel / room_id はそのまま載せる（matrix-webhook 側の解釈）。
+    def test_build_body_carries_room
+      shrieker = WebhookShrieker.create(
+        'url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#matrix-news:example.com',
+      )
+      body = shrieker.build_body(template: template(SPOILER))
+
+      assert_equal('#matrix-news:example.com', body[:channel])
+    end
+
+    # ⚠⚠ **Source の配線まで見る。** Shrieker 単体のテストだけだと、
+    # `Source#shriekers` が `create` ではなく `new` を呼ぶ実装に戻っても気づけない。
+    def test_source_shriekers_selects_tsunagal
+      source = Source.new(
+        'id' => '__test_tsunagal__',
+        'dest' => {
+          'hooks' => [
+            {'url' => HOOK_URL, 'type' => 'tsunagal', 'channel' => '#x:example.com'},
+            'https://mstdn.example.com/mulukhiya/webhook/deadbeef',
+          ],
+        },
+      )
+
+      assert_equal(
+        [TsunagalWebhookShrieker, WebhookShrieker],
+        source.shriekers.map(&:class),
+      )
+    end
+
+    private
+
+    def tsunagal
+      return TsunagalWebhookShrieker.new(HOOK_URL)
+    end
+
+    # Template のふりをする最小の stub。⚠ 実 Template は ERB を評価するので、
+    # ここでは「to_s が本文を返し、source.spoiler_text を持つ」ことだけ満たす。
+    def template(spoiler_text)
+      source = Object.new
+      source.define_singleton_method(:spoiler_text) {spoiler_text}
+      stub = Object.new
+      stub.define_singleton_method(:to_s) {TEXT}
+      stub.define_singleton_method(:source) {source}
+      stub.define_singleton_method(:[]=) {|key, value| (@slots ||= {})[key] = value}
+      stub.define_singleton_method(:[]) {|key| (@slots ||= {})[key]}
+      return stub
+    end
+  end
+end


### PR DESCRIPTION
マイルストーン 4.7.0（8 Issue）を消化したリリース。**security 3 件**を含みます。

## 🔴 security

### 資格情報が 3 経路で漏れていた

`https://<host>/mulukhiya/webhook/{digest}` は **digest を知っていれば誰でも投稿できる** ＝ URL そのものが資格情報です。これが**成功した POST のたびに平文で syslog へ**出ていました（本番の当日ログで 22 行）。

| 経路 | 対応 |
| --- | --- |
| syslog（`HTTP#log` の `url:`） | [ginseng-core#580](https://github.com/pooza/ginseng-core/issues/580) — `mask_url` が**クエリしか見ていなかった**。`/logger/mask_url_paths` を新設（**1.21.0**） |
| syslog（例外メッセージに埋まった URL） | [ginseng-core#582](https://github.com/pooza/ginseng-core/issues/582) — `URL_PATTERN` の `\A` 錨で `mask_url` に届いていなかった（**1.22.0**） |
| Sentry | **#1467** — `before_send` を追加 |
| `source_run_log` / `/status.json` | **#1511** — 書く前にマスク＋保護行の `error_message` を期限で NULL 化 |

⚠ **#582 が入るまで #580 は「呼ばれないので効かない」状態でした。**

### そのほか

- **#1524** `ginseng-*` を追随（`ginseng-core` 1.19.0 → **1.22.0** / `ginseng-fediverse` 1.8.28 → **1.8.31**）。⚠ **別オリジンへのリダイレクトで query / `basic_auth` / `cookies` が渡っていた**穴 3 件と、`post`/`put`/`delete` で `host_validator` が効いていなかった穴を含みます
- **#1530** `Config#load` が `config/sources` を 1 件ずつ積んでおり、🔴 **途中で YAML が壊れると `/sources` が半端な状態で残っていました**

## 機能・修正

- **#1493** matrix-webhook 宛で CW（`spoiler_text`）が**エラーにもならず落ちていた**。`TsunagalWebhookShrieker` を切り、CW を本文の先頭へ畳みます
- **#1514** `PiefedShrieker` の login を投稿時へ遅らせる（構築しただけで認証 API を叩かない）
- **#1471** `/status.json` に Ruby ランタイム情報（`version` / `yjit_available` / `yjit_enabled`）
- **#1513** `source ack` の日数表示が整数除算で「0日」になる
- **#1512** `/healthz/source` の 503 本文が凍結予定のリテラルを破壊的更新（将来 `FrozenError` で診断情報が消える）
- **#1490** 4.5.0 レビュー由来の整理

## ⚠ 運用者向け

- 🔴 **本番の matrix 系 3 ソースに `type: tsunagal` を 1 行足すまで、CW は落ちたままです**（`matrix-news` / `matrix-element-web-release` / `matrix-synapse-release`）。⚠ **足さなくても壊れません**
- **設定の追加は不要です。**v4.6.1 の `/http/timeout/seconds` のような必須キーの追加はありません
- 🔴 **サテライト 3 本も同時に pull してください**（`ginseng-core` を 1.22.0 へ追随する必要があります）

## 検証

### リリース前レビュー（5 観点）

⚠ **並列サブエージェントではなく順に実施。**赤 1 件・黄 1 件を **PR #1539** で対応済み、緑 1 件は **#1538**（4.8.0）へ送りました。

- 🔴 `SentryScrubber` の scrub 失敗通知が `warn` ＝ **本番では `/dev/null`**（daemon が stderr を潰す）。scrub が壊れると Sentry へ何も届かないのに誰も気づけない
- 🟡 `Package.error_class_of` が名前空間付きクラス名で壊れる（`Ginseng::GatewayError` → `Ginseng`）

### リリース前検証（release-validation.md）— 全項目パス

- ✅ `source list` で test-* 8 件すべて認識
- ✅ `fetch` 成功 — GitHub (10 entries) / Icalendar (4) / GoogleNews+cleaner (25) / YouTube (15)
- ✅ **cleaner 経由で実 publisher URL**（`news.google.com` のリダイレクト URL は **0 件**）
- ✅ **PieFed テストコミュニティに実投稿が反映**（`2026-08-25T08:48:17Z`）
- ✅ **#1514 の遅延 login を実機確認** — 構築直後 `absent` → `login` 後 `present`

`rake test` **239 tests / 0 failures / 0 errors**、RuboCop 無指摘（91 files）。