### PR TITLE
chore: バージョンを 4.8.0 にバンプする

### DIFF
--- a/config/application.yaml
+++ b/config/application.yaml
@@ -55,7 +55,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.7.0
+  version: 4.8.0
 nostr:
   relays:
     - wss://relay.damus.io


### PR DESCRIPTION
マイルストーン 4.8.0（9 件）着手にあたってのバージョンバンプ。

⚠ **バンプは「開発中の版の識別」であって、リリースの合図ではありません。**出荷を確定させるのはタグです。動いているコードがどの版か分からないと、デプロイと検証で事故ります（[workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。

**本番は v4.7.0** で稼働中です（`main` = `76808bc`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)