### PR TITLE
fix: 無効ソースを監視対象外にする (#1503)

### DIFF
--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -43,11 +43,14 @@ module TomatoShrieker
     def build_healthz_source(source_id)
       source = Source.create(source_id)
       return [404, HEADERS, ["Unknown source: #{source_id}\n"]] unless source
+      # 意図的に止めたソースを「壊れている」と混同しない (#1503)。
+      return [200, HEADERS, ["OK (disabled)\n"]] if source.disable?
       return [200, HEADERS, ["OK (not monitored)\n"]] unless source.monitored?
       # 宛先ゼロは実行結果を見るまでもなく壊れている (#1473)。
-      # ⚠ 無効ソースは除く。スキーマが disable: true のとき dest の必須を免除しており
-      # (chinachu 等の死蔵定義が実際に dest: {})、ランタイムだけ咎めると食い違う (#1486)。
-      return [503, HEADERS, ["No destination configured\n"]] unless source.dest? || source.disable?
+      # ⚠ 無効ソースはここまで来ない (#1503)。スキーマが disable: true のとき dest の
+      # 必須を免除している (chinachu 等の死蔵定義が実際に dest: {}) 件 (#1486) も、
+      # 「無効なら監視しない」で一括して片付く。
+      return [503, HEADERS, ["No destination configured\n"]] unless source.dest?
       latest = SourceRunLog.latest_for(source_id)
       return [503, HEADERS, ["No run recorded yet\n"]] unless latest
       checks = source_checks(source, latest)

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -343,7 +343,12 @@ module TomatoShrieker
       return SourceRunLog.undelivered?(id)
     end
 
+    # 監視の対象か (#1503)。
+    # ⚠ 無効ソースは scheduler が register しないので executed_at が前に進まず、
+    # 一度稼働してから無効化すると stale 判定が恒久的に成立して赤が貼り付く。
+    # 「無効なソースは監視しない」で /status.json の reject(&:disable?) と揃える。
     def monitored?
+      return false if disable?
       return post_at.nil?
     end
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -251,11 +251,13 @@ scheduler プロセス生存 + DB 接続 + Rufus ジョブが 1 件以上、す�
 
 ソースが存在しない場合は 404。`/schedule/at` の単発ソースは監視対象外として常に 200 を返す。
 
+🔴 **`disable: true` のソースも監視対象外で、常に `OK (disabled)` の 200 (#1503)。**scheduler は `reject(&:disable?)` で無効ソースを register しないので `executed_at` が二度と前に進まない。**一度稼働してから無効化すると `stale` が恒久的に成立し、Kuma のモニターが永久に赤くなる**（無効化直後は 200 なのでその場では気付けない）。⚠ **「意図的に止めた」と「壊れている」を同じ 503 で表さない。**`/status.json` が `reject(&:disable?)` しているのと同じ規則で揃えてある。
+
 **宛先ゼロは実行結果を見るまでもなく壊れている (#1473)。**`No destination configured` を返して 503 に倒す。`dest: {}` や `dest: {hooks: []}`、`token` を落とした `dest.mastodon` のような半端な設定は `shriekers` が 1 件も yield しないため配信が永久に起きないが、run は no-op success を積むだけで健全に見える。
 
 🔴 **設定は正しいのに Shrieker を組み立てられない場合も同じ穴になる (#1504)。**各アクセサ（`mastodon` / `misskey` / `line` / `piefed` / `nostr`）は生成時の例外を `rescue` して nil を返すので、**PieFed が落ちている・上流が 429 を返す・URL のスキームが欠けている**といった理由でその宛先が `shriekers` から黙って消える。`dest_count` は設定を数えるだけなので気付けない。`Source#shriek` が `dest_count` と yield 数の差を `record_unavailable` で計上し、未達として倒す。⚠ **この差分を計上しないと `dest_count` は「表示するだけの数字」になる。**
 
-⚠ **ただし `disable: true` のソースは除く (#1486)。**スキーマが無効ソースに対して `dest` の配信先必須を免除している（`chinachu` 等の死蔵定義が実際に `dest: {}`）ので、ランタイムだけ咎めると宣言と食い違う。無効ソースは `register` されず run_log も無いため、`No run recorded yet` の 503 に落ちる。
+⚠ **ただし `disable: true` のソースは除く (#1486)。**スキーマが無効ソースに対して `dest` の配信先必須を免除している（`chinachu` 等の死蔵定義が実際に `dest: {}`）ので、ランタイムだけ咎めると宣言と食い違う。**#1503 以降、無効ソースは宛先チェックの手前で 200 に抜ける**ので、この食い違いは監視の入口で片付いている。
 
 **エラー判定は連続エラー回数 (error_streak) で行う (#1457)。**streak はエラーで終わった run を新しい順に数え、**エラーでない run が来た時点で 0 に戻る**。新着が無く配信ゼロで完走した run (no-op) も「run が最後まで走った」証拠なので streak を切る。
 

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -114,15 +114,28 @@ module TomatoShrieker
     end
 
     # #1486: スキーマは disable: true のとき dest の必須を免除しているので、
-    # ランタイムだけ「宛先がない」と咎めると食い違う
+    # ランタイムだけ「宛先がない」と咎めると食い違う。
+    # ⚠ #1503 で「無効なソースは監視しない」に統一したので、run の有無に関わらず 200。
     def test_healthz_source_disabled_without_dest
       write_fixture(DISABLED_ID, {'disable' => true, 'dest' => {}})
       config.reload
       status, _headers, body = call("/healthz/source/#{DISABLED_ID}")
 
-      assert_equal(503, status)
-      assert_not_include(body.first, 'No destination configured')
-      assert_include(body.first, 'No run recorded yet')
+      assert_equal(200, status)
+      assert_include(body.first, 'OK (disabled)')
+    end
+
+    # #1503: 一度稼働してから無効化したソースは run_log が残るので stale 判定まで進み、
+    # しかも scheduler が register しないので executed_at が二度と前に進まない。
+    # grace を跨いだ時点で恒久的に 503 になっていた。
+    def test_healthz_source_disabled_after_running
+      write_fixture(DISABLED_ID, {'disable' => true})
+      config.reload
+      record(DISABLED_ID, attempted_count: 1, delivered_count: 1, at: Time.now - 86_400)
+      status, _headers, body = call("/healthz/source/#{DISABLED_ID}")
+
+      assert_equal(200, status)
+      assert_include(body.first, 'OK (disabled)')
     end
 
     # #1457: 一過性エラーのあと no-op success が来たら健全に戻る。

--- a/test/source.rb
+++ b/test/source.rb
@@ -255,7 +255,8 @@ module TomatoShrieker
     def test_monitored?
       Source.all.each do |source|
         assert_boolean(source.monitored?)
-        assert_equal(source.post_at.nil?, source.monitored?)
+        # #1503: 無効ソースは scheduler に register されないので監視もしない
+        assert_equal(!source.disable? && source.post_at.nil?, source.monitored?)
       end
     end
 


### PR DESCRIPTION
Closes #1503

## なぜ

**稼働していたソースを `disable: true` にすると、約 2 時間後に `/healthz/source/<id>` が 503 になり、以後ずっと赤のまま**だった。

scheduler は `reject(&:disable?)` で無効ソースを register しないので `executed_at` が二度と前に進まない。一方 `Source#monitored?` は `post_at` しか見ていなかったため無効ソースも `stale` 判定まで進み、`Time.now > next_run + grace` が恒久的に成立する。

⚠ **無効化した直後は 200 を返す**ので、その場の確認では気付けない。🔴 **Kuma にソース別モニターを登録していると、無効化のたびに永久の赤が増える。**

## どう直したか

**「無効なソースは監視しない」**の一文で説明できる形に揃えた。`/status.json` が既に `reject(&:disable?)` しているのと同じ規則。

- `Source#monitored?` に `disable?` を足す
- `/healthz/source` は**宛先チェックの手前**で `OK (disabled)` の 200 を返す（`OK (not monitored)` と本文で区別できる）

⚠ **#1486（スキーマが無効ソースの `dest` 必須を免除しているので、ランタイムだけ咎めない）は監視の入口で一括して片付く**ため、`No destination configured` の分岐から `|| source.disable?` を落とした。`test_healthz_source_disabled_without_dest` は 503 固定から 200 固定へ書き換えている。

## 確認したこと

- `bundle exec rake test`: **240 tests, 904 assertions, 0 failures, 0 errors**
- `bundle exec rubocop`: **92 files inspected, no offenses detected**
- ⚠ **`app/lib` の変更だけ stash すると `test_healthz_source_disabled_without_dest` と新規の `test_healthz_source_disabled_after_running` の 2 件が落ちる**ことを確認（テストが空振りしていない）
- docs/CLAUDE.md の #1486 の記述（「無効ソースは `No run recorded yet` の 503 に落ちる」）を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcksxjVq8KutvzojvQ8rxt