### PR TITLE
feat: ソース定義を稼働中に reload する (#1459)

### DIFF
--- a/app/lib/tomato_shrieker/cli/source_command.rb
+++ b/app/lib/tomato_shrieker/cli/source_command.rb
@@ -6,52 +6,6 @@ module TomatoShrieker
   class SourceCommand < Thor
     include Package
 
-    # `add --class` で生成する雛形の共通パーツ。
-    DEFAULT_DEST = {
-      'hooks' => ['https://mastodon.example.com/mulukhiya/webhook/CHANGE_ME'],
-      'tags' => [],
-    }.freeze
-    DEFAULT_SCHEDULE = {'cron' => '0 0 * * *'}.freeze
-
-    # `add --class` で生成する種別ごとの雛形。いずれもスキーマ妥当な最小構成。
-    TEMPLATES = {
-      'feed' => {
-        'source' => {'feed' => 'https://example.com/feed'},
-        'dest' => DEFAULT_DEST,
-      },
-      'url' => {
-        'source' => {'url' => 'https://example.com/'},
-        'dest' => DEFAULT_DEST,
-      },
-      'news' => {
-        'source' => {'news' => {'phrase' => 'CHANGE_ME'}},
-        'dest' => DEFAULT_DEST,
-      },
-      'github' => {
-        'source' => {'github' => {'repository' => 'owner/repo', 'timeline' => 'releases'}},
-        'dest' => DEFAULT_DEST,
-      },
-      'icalendar' => {
-        'source' => {'ical' => 'https://example.com/calendar.ics'},
-        'schedule' => DEFAULT_SCHEDULE,
-        'dest' => DEFAULT_DEST,
-      },
-      'youtube' => {
-        'source' => {'youtube' => {'channel' => {'url' => 'https://www.youtube.com/@CHANGE_ME'}}},
-        'dest' => DEFAULT_DEST,
-      },
-      'command' => {
-        'source' => {'command' => ['echo', 'hello'], 'dir' => '/path/to/workdir'},
-        'schedule' => DEFAULT_SCHEDULE,
-        'dest' => DEFAULT_DEST,
-      },
-      'text' => {
-        'source' => {'text' => 'CHANGE_ME'},
-        'schedule' => DEFAULT_SCHEDULE,
-        'dest' => DEFAULT_DEST,
-      },
-    }.freeze
-
     desc 'list', 'ソース一覧 (id とクラス名) を表示'
     def list
       Source.all do |source|
@@ -86,14 +40,14 @@ module TomatoShrieker
 
     desc 'add ID', '雛形を生成し $EDITOR で編集してソース定義を作成'
     method_option :class, type: :string, default: 'feed',
-      desc: "ソース種別 (#{TEMPLATES.keys.join('/')})"
+      desc: "ソース種別 (#{SourceTemplates::ALL.keys.join('/')})"
     def add(id)
       raise Thor::Error, "invalid id: #{id}" unless id.match?(/\A[\w.-]+\z/)
       path = new_source_path(id)
       raise Thor::Error, "source already exists: #{id}" if File.exist?(path)
-      template = TEMPLATES[options[:class]]
+      template = SourceTemplates::ALL[options[:class]]
       unless template
-        raise Thor::Error, "unknown class: #{options[:class]} (#{TEMPLATES.keys.join('/')})"
+        raise Thor::Error, "unknown class: #{options[:class]} (#{SourceTemplates::ALL.keys.join('/')})"
       end
       File.write(path, template.to_yaml)
       edit_and_validate(id, path)
@@ -110,6 +64,7 @@ module TomatoShrieker
       return unless yes?("delete #{path} ? [y/N]")
       File.delete(path)
       say "deleted: #{path}"
+      say reload_hint
     end
 
     desc 'disable ID', 'ソースを停止 (disable: true)'
@@ -133,6 +88,24 @@ module TomatoShrieker
       say "#{id} を確認済みにしました。"
       # ⚠ 「今後も問題ない」の保証ではないことを操作のたびに示す。
       say "  次に silence_tolerance (#{tolerance_label(source)}) を超えたら、再び警告します。"
+    end
+
+    desc 'reload', '稼働中の scheduler にソース定義を読み直させる (SIGHUP)'
+    def reload
+      daemon = SchedulerDaemon.new
+      case daemon.alive_state
+      when :alive
+        pid = daemon.pid
+        Process.kill('HUP', pid)
+        say "reload requested (pid #{pid})"
+        # ⚠ シグナルは非同期なので、CLI は「要求した」までしか言えない (#1529)。
+        say '  結果はログの {"scheduler":"reload",...} 行で確認できます。'
+      when :unknown
+        # ⚠ :unknown（EPERM）を :dead と混ぜない。プロセスは生きている可能性がある。
+        raise Thor::Error, "PID #{daemon.pid} exists but is not ours. reload できません。"
+      else
+        say 'scheduler は停止しています。ソース定義は次回起動時に読み込まれます。'
+      end
     end
 
     desc 'validate [ID]', 'ソース定義を JSON Schema で検証（ID 省略時は全件）'
@@ -188,6 +161,7 @@ module TomatoShrieker
       errors = SourceValidator.validate(YAML.load_file(path))
       if errors.empty?
         say "OK: #{path}"
+        say reload_hint
       else
         warn "WARNING: #{id} の定義にスキーマ違反があります:"
         errors.each {|e| warn "    - #{e}"}
@@ -217,6 +191,15 @@ module TomatoShrieker
       end
       File.write(path, lines.join)
       say "#{value ? 'disabled' : 'enabled'}: #{id}"
+      say reload_hint
+    end
+
+    # ⚠ **自動 reload はしない (#1459)。**add / edit / delete / disable / enable の
+    # 契約を 1 つずつのままに保つ。自動にすると「エディタを閉じただけで本番へ反映
+    # される」「validate NG のとき」「daemon が停止中のとき」の分岐を全部説明する
+    # ことになる。代わりに、反映がまだであることを操作のたびに言う。
+    def reload_hint
+      return '⚠ 稼働中の scheduler に反映するには bin/shrieker source reload'
     end
 
     def sources_dir

--- a/app/lib/tomato_shrieker/cli/source_templates.rb
+++ b/app/lib/tomato_shrieker/cli/source_templates.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module TomatoShrieker
+  # `bin/shrieker source add --class` が生成する雛形 (#1429)。
+  # ⚠ SourceCommand から切り出しただけ。ここに振る舞いは置かない。
+  module SourceTemplates
+    # `add --class` で生成する雛形の共通パーツ。
+    DEFAULT_DEST = {
+      'hooks' => ['https://mastodon.example.com/mulukhiya/webhook/CHANGE_ME'],
+      'tags' => [],
+    }.freeze
+    DEFAULT_SCHEDULE = {'cron' => '0 0 * * *'}.freeze
+
+    # `add --class` で生成する種別ごとの雛形。いずれもスキーマ妥当な最小構成。
+    ALL = {
+      'feed' => {
+        'source' => {'feed' => 'https://example.com/feed'},
+        'dest' => DEFAULT_DEST,
+      },
+      'url' => {
+        'source' => {'url' => 'https://example.com/'},
+        'dest' => DEFAULT_DEST,
+      },
+      'news' => {
+        'source' => {'news' => {'phrase' => 'CHANGE_ME'}},
+        'dest' => DEFAULT_DEST,
+      },
+      'github' => {
+        'source' => {'github' => {'repository' => 'owner/repo', 'timeline' => 'releases'}},
+        'dest' => DEFAULT_DEST,
+      },
+      'icalendar' => {
+        'source' => {'ical' => 'https://example.com/calendar.ics'},
+        'schedule' => DEFAULT_SCHEDULE,
+        'dest' => DEFAULT_DEST,
+      },
+      'youtube' => {
+        'source' => {'youtube' => {'channel' => {'url' => 'https://www.youtube.com/@CHANGE_ME'}}},
+        'dest' => DEFAULT_DEST,
+      },
+      'command' => {
+        'source' => {'command' => ['echo', 'hello'], 'dir' => '/path/to/workdir'},
+        'schedule' => DEFAULT_SCHEDULE,
+        'dest' => DEFAULT_DEST,
+      },
+      'text' => {
+        'source' => {'text' => 'CHANGE_ME'},
+        'schedule' => DEFAULT_SCHEDULE,
+        'dest' => DEFAULT_DEST,
+      },
+    }.freeze
+  end
+end

--- a/app/lib/tomato_shrieker/daemon/scheduler_daemon.rb
+++ b/app/lib/tomato_shrieker/daemon/scheduler_daemon.rb
@@ -23,11 +23,37 @@ module TomatoShrieker
       migrate(db)
       @monitor_server = MonitorServer.new
       @monitor_server.start
+      start_reload_worker
       Scheduler.instance.exec
     rescue => e
       Sentry.capture_exception(e) if Sentry.initialized?
       logger.error(daemon: app_name, error: e)
       raise
+    end
+
+    # SIGHUP でソース定義を読み直す (#1459)。`bin/shrieker source reload` が送る。
+    #
+    # ⚠ **trap 文脈では Mutex を取れない**（`ThreadError`）。`Scheduler#reload` は
+    # Mutex を取るので、**trap は Queue に積むだけ**にして専用スレッドが処理する。
+    #
+    # ⚠ `Ginseng::Daemon#run_start` は override しない。あちらの `abort_if_running!` /
+    # `write_pid` / TERM・INT の trap を複製することになる。ここで張れば足りる。
+    def start_reload_worker
+      @reload_queue = Thread::Queue.new
+      @reload_thread = Thread.new do
+        # ⚠ `stop` が `close` すると `pop` は nil を返す。そこで抜ける。
+        while @reload_queue.pop
+          begin
+            Scheduler.instance.reload
+          rescue => e
+            # ⚠ **reload の失敗で daemon を落とさない。**壊れた YAML を掴んだだけなら
+            # 古い定義のまま走り続けるのが正しい。
+            Sentry.capture_exception(e) if Sentry.initialized?
+            logger.error(scheduler: 'reload', error: e)
+          end
+        end
+      end
+      trap('HUP') {@reload_queue.push(true)}
     end
 
     # #1410 で rake start/restart を廃止したとき、その前提タスクだった migration:run が
@@ -46,6 +72,7 @@ module TomatoShrieker
 
     def stop
       logger.info(daemon: app_name, version: Package.version, message: 'stop')
+      @reload_queue&.close
       @monitor_server&.stop
       Scheduler.instance.scheduler.shutdown(:kill)
     end

--- a/app/lib/tomato_shrieker/scheduler.rb
+++ b/app/lib/tomato_shrieker/scheduler.rb
@@ -3,11 +3,10 @@ module TomatoShrieker
     include Singleton
     include Package
 
-    attr_reader :scheduler
+    attr_reader :scheduler, :registry
 
     def exec
-      in_threads = Parallel.processor_count * 2
-      Parallel.each(Source.all.reject(&:disable?), in_threads:, &:register)
+      register_all
       schedule_maintenance
       @scheduler.join
     rescue => e
@@ -15,14 +14,84 @@ module TomatoShrieker
       logger.error(scheduler: {error: e})
     end
 
+    # ソース定義を読み直し、**差分だけ**ジョブに反映する (#1459)。
+    #
+    # ⚠ **全件を貼り替えてはいけない。**`every` は登録時に発火しない代わりに
+    # 次回発火が 1 周期先へずれるので、無変更のソースまで貼り替えると全ソースの
+    # 位相がリセットされる。無変更なら**ジョブに触らない**。
+    #
+    # ⚠ **実行中の run は殺さない。**`unschedule` は以後の発火を止めるだけで、
+    # 進行中の run は古い定義のまま完走する。これは仕様。
+    #
+    # ⚠ **スキーマ検証はしない。**起動時が検証していないのに reload だけ厳しいと
+    # 「起動はできるのに reload は拒否される」定義が生まれる。検証は CLI の
+    # `source edit` / `source validate` の担当。
+    def reload
+      @reload_mutex.synchronize do
+        # 壊れた YAML があればここで raise する。#1530 以降 Config#load は読み切って
+        # から 1 回で差し替えるので、**設定もジョブも何も変わらないまま**抜ける。
+        Config.instance.reload
+        apply(desired_sources)
+      end
+    end
+
     private
 
     def initialize
       @scheduler = Rufus::Scheduler.new
+      # id => 設定の digest。無変更のソースを見分けるためだけに持つ。
+      @registry = {}
+      @reload_mutex = Mutex.new
+    end
+
+    def apply(desired)
+      digests = desired.transform_values {|v| digest(v)}
+      removed = @registry.keys - digests.keys
+      stale = digests.reject {|id, d| @registry[id] == d}.keys
+      added = stale - @registry.keys
+      removed.each do |id|
+        unschedule(id)
+        @registry.delete(id)
+      end
+      stale.each do |id|
+        unschedule(id)
+        desired[id].each(&:register)
+        @registry[id] = digests[id]
+      end
+      result = {added:, removed:, changed: stale - added}
+      logger.info({scheduler: 'reload'}.merge(result))
+      return result
+    end
+
+    def register_all
+      desired = desired_sources
+      in_threads = Parallel.processor_count * 2
+      Parallel.each(desired.values.flatten, in_threads:, &:register)
+      desired.each {|id, sources| @registry[id] = digest(sources)}
+    end
+
+    # 有効なソースを id 単位でまとめる。⚠ 1 つの定義が複数のソースクラスに
+    # マッチしうる（`Source.all` はマッチしたクラスぶん yield する）ので、
+    # 1 つの id が複数のインスタンスを持ちうる。
+    def desired_sources
+      return Source.all.reject(&:disable?).group_by(&:id)
+    end
+
+    # ⚠ **job id ではなく tag で消す。**`IcalendarSource#register` は remind と本体の
+    # 2 本を同じ `tag: id` で登録し、戻り値は本体ぶんだけなので、job id を控える
+    # 設計にすると remind ジョブが取り残される。
+    def unschedule(id)
+      @scheduler.jobs(tag: id).each(&:unschedule)
+    end
+
+    # ⚠ `class` は除く。同じ定義が複数クラスにマッチしても digest は 1 つ。
+    def digest(sources)
+      return Digest::SHA1.hexdigest(sources.first.to_h.except('class').to_json)
     end
 
     def schedule_maintenance
       retention = Config.instance['/monitor/retention_days']
+      # ⚠ **無タグ**。reload は tag で消すので、この日次ジョブは巻き込まれない。
       @scheduler.every '1d', first_in: '1m' do
         count = SourceRunLog.prune(retention)
         logger.info(scheduler: 'maintenance', action: 'prune', retention_days: retention,

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -146,6 +146,7 @@ systemd/rc.d → bin/scheduler_daemon.rb start
       → Sequel.connect (SQLite3)
       → SchedulerDaemon#migrate (未適用ならマイグレーション)
       → MonitorServer#start (Puma embedded / 監視用 HTTP)
+      → SchedulerDaemon#start_reload_worker (SIGHUP → Queue → Scheduler#reload)
       → Scheduler.instance.exec (Rufus::Scheduler)
         → Source.all → register (各ソースをスケジューラに登録)
 ```
@@ -157,6 +158,36 @@ systemd/rc.d からは bin スクリプトを直接呼ぶ。`rake start` / `rake
 **未適用のマイグレーションは起動時に自動適用される。**デプロイ手順に `rake migrate` を書き忘れても、スキーマが古いまま走ることはない。適用済みなら何もしない（`Sequel::Migrator.is_current?` で判定）。失敗した場合は起動させずに落とす — 古いスキーマのまま動くと、実行時に分かりにくい形で壊れるため。
 
 ⚠ もともと `rake start` / `rake restart` の前提タスク（`migration:run`）として走っていたが、#1410 で rake タスクを廃止したときに一緒に落ちて手動になっていた。`rake migrate` は手動実行用に残してある。
+
+### ソース定義の reload (#1459)
+
+**稼働中の scheduler にソース定義を読み直させる。**`bin/shrieker source add / edit / delete / disable / enable` はファイルを書くだけなので、以前は反映に再起動が要った。
+
+```sh
+bin/shrieker source disable foo
+# disabled: foo
+# ⚠ 稼働中の scheduler に反映するには bin/shrieker source reload
+
+bin/shrieker source reload
+# reload requested (pid 1322485)
+```
+
+`source reload` は `tmp/pids/SchedulerDaemon.pid` を読んで **SIGHUP** を送る。daemon 側は trap で Queue に積み、専用スレッドが `Scheduler#reload` を呼ぶ。⚠ **trap 文脈では Mutex を取れない**（`ThreadError`）ので、trap で直接 reload してはいけない。
+
+🔴 **reload するのは「ソース定義」だけ。**`Ginseng::Config#load` は `next if @raw.key?(key)` で一度読んだファイルを二度と読まないため、`application.yaml` / `local.yaml` は反映されない。⚠ **「reload ＝ 設定を全部読み直す」と説明すると嘘になる。**`/monitor/bind` のようなキーを稼働中に差し替えられても困るので、これは**仕様として維持する**（コマンド名が `source reload` なのはそのため）。
+
+**差分だけをジョブに反映する。**id 単位で設定の digest を持ち、**無変更のソースはジョブに触らない**。
+
+- ⚠ **全件を貼り替えてはいけない。**`every` は登録時に発火しない代わりに、差し替えると**次回発火が 1 周期先へずれる**。全件貼り替えは全ソースの位相をリセットする
+- ⚠ **消すのは job id ではなく tag。**`IcalendarSource#register` は remind と本体の 2 本を**同じ `tag: id`** で登録し、`register` の戻り値は本体ぶんだけ。job id を控える設計にすると remind ジョブが取り残される
+- ⚠ `schedule_maintenance`（prune）の日次ジョブは**無タグ**。「全部 unschedule」をやると巻き添えで消える
+- ⚠ **実行中の run は殺さない。**`unschedule` は以後の発火を止めるだけなので、**進行中の run は古い定義のまま完走する**
+- 🔴 **壊れた定義を掴んだら何も変えない。**`Config#load` は読み切ってから 1 回で差し替える（#1530）ので、YAML が 1 つでも壊れていれば例外だけが上がり、**ジョブも設定も前のまま**走り続ける
+- ⚠ **reload ではスキーマ検証をしない。**起動時が検証していないのに reload だけ厳しいと「起動はできるのに reload は拒否される」定義が生まれる。検証は `source edit` / `source validate` の担当
+
+⚠ **自動 reload はしない。**`add` / `edit` の契約を 1 つずつのままに保つため（`source add` は $EDITOR を開く**前に**スキーマ妥当な雛形を書くので、ファイル監視だと `example.com` へ投げるジョブが即座に立つ）。⚠ **監視エンドポイントに `POST /reload` も置かない。**読み取り専用だった監視面が制御面になる。
+
+⚠ **シグナルは非同期なので、CLI は「要求した」までしか言えない。**結果はログの `{"scheduler":"reload","added":[...],"removed":[...],"changed":[...]}` 行で見る（同期で受け取る手段は #1529）。daemon が停止中なら「次回起動時に読み込まれます」と言って正常終了し、`:unknown`（EPERM ＝ pid のプロセスに触れない）はエラーにする。⚠ **`:unknown` を `:dead` と混ぜない。**
 
 ### デプロイ手順
 
@@ -288,8 +319,10 @@ bin/shrieker source ack ID
 | 状況 | 対処 |
 |------|------|
 | 一時的に静か（たまたま 1 か月新着が無かった） | `bin/shrieker source ack ID` |
-| 投稿が恒久的に終了した | `bin/shrieker source disable ID` |
+| 投稿が恒久的に終了した | `bin/shrieker source disable ID`（＋ `source reload`） |
 | 年単位で正常に静か（`chikanan` 等） | `silence_tolerance` を設定しない |
+
+⚠ **`disable` にしたソースは監視対象外になり、`/healthz/source/:id` は `OK (disabled)` の 200 を返す (#1503)。**「意図的に止めた」と「壊れている」を同じ 503 で表さない。
 
 ⚠ **判定に使うのは run_log 由来の実配信だけで、`fallback` は見ない (#1483)。**下記のとおり `fallback` は配信の成否と無関係に前進するため、これを信じると配信できていなくても `silent?` が永久に false になる。
 

--- a/test/scheduler.rb
+++ b/test/scheduler.rb
@@ -1,0 +1,151 @@
+module TomatoShrieker
+  class SchedulerTest < TestCase
+    # config/sources は環境ごとに中身が違うので、テスト専用の定義を置いてから確かめる。
+    FIXTURE_ID = '__test_scheduler__'.freeze
+    OTHER_ID = '__test_scheduler_other__'.freeze
+    ICAL_ID = '__test_scheduler_ical__'.freeze
+    BROKEN_ID = '__test_scheduler_broken__'.freeze
+    IDS = [FIXTURE_ID, OTHER_ID, ICAL_ID, BROKEN_ID].freeze
+
+    # teardown は異常終了で走らない。config/sources/.gitignore が `*` なので取り残しは
+    # git status にも出ず、次のスケジューラ起動で偽ソースとして登録されてしまう。
+    at_exit do
+      Dir.glob(File.join(Environment.dir, 'config/sources', '__test_scheduler*.yaml'))
+        .each {|f| FileUtils.rm_f(f)}
+    end
+
+    def setup
+      @scheduler = Scheduler.instance
+      IDS.each {|id| FileUtils.rm_f(fixture_path(id))}
+      write_fixture(FIXTURE_ID, {})
+      @scheduler.reload
+    end
+
+    def teardown
+      IDS.each {|id| FileUtils.rm_f(fixture_path(id))}
+      # ⚠ Scheduler は Singleton なので、テストが張ったジョブは以後もプロセスに残る。
+      @scheduler.scheduler.jobs.each(&:unschedule)
+      @scheduler.registry.clear
+      super # TestCase#teardown が config.reload する
+    end
+
+    def fixture_path(id)
+      return File.join(Environment.dir, 'config/sources', "#{id}.yaml")
+    end
+
+    def write_fixture(id, extra)
+      values = {
+        'source' => {'feed' => "https://example.com/#{id}.rss"},
+        'schedule' => {'every' => '1d'},
+        'dest' => {'hooks' => ["https://example.com/#{id}/hook"]},
+      }.deep_merge(extra)
+      File.write(fixture_path(id), YAML.dump(values))
+    end
+
+    def jobs(id)
+      return @scheduler.scheduler.jobs(tag: id)
+    end
+
+    def test_reload_adds_source
+      assert_empty(jobs(OTHER_ID))
+      write_fixture(OTHER_ID, {})
+      result = @scheduler.reload
+
+      assert_equal(1, jobs(OTHER_ID).size)
+      assert_include(result[:added], OTHER_ID)
+    end
+
+    def test_reload_removes_source
+      assert_equal(1, jobs(FIXTURE_ID).size)
+      FileUtils.rm_f(fixture_path(FIXTURE_ID))
+      result = @scheduler.reload
+
+      assert_empty(jobs(FIXTURE_ID))
+      assert_include(result[:removed], FIXTURE_ID)
+    end
+
+    def test_reload_replaces_changed_source
+      write_fixture(FIXTURE_ID, {'schedule' => {'every' => '2d'}})
+      result = @scheduler.reload
+
+      assert_equal(1, jobs(FIXTURE_ID).size)
+      assert_equal('2d', jobs(FIXTURE_ID).first.original)
+      assert_include(result[:changed], FIXTURE_ID)
+    end
+
+    # 🔴 **無変更のソースはジョブに触らない。**`every` は差し替えると次回発火が
+    # 1 周期先へずれるので、全件を貼り替えると全ソースの位相がリセットされる。
+    def test_reload_keeps_unchanged_job
+      job = jobs(FIXTURE_ID).first
+      write_fixture(OTHER_ID, {}) # 別のソースを足しても FIXTURE_ID には波及しない
+      result = @scheduler.reload
+
+      assert_equal(job.job_id, jobs(FIXTURE_ID).first.job_id)
+      assert_equal(job.next_time, jobs(FIXTURE_ID).first.next_time)
+      assert_not_include(result[:changed], FIXTURE_ID)
+    end
+
+    def test_reload_disable_and_enable
+      write_fixture(FIXTURE_ID, {'disable' => true})
+      @scheduler.reload
+
+      assert_empty(jobs(FIXTURE_ID))
+
+      write_fixture(FIXTURE_ID, {})
+      result = @scheduler.reload
+
+      assert_equal(1, jobs(FIXTURE_ID).size)
+      assert_include(result[:added], FIXTURE_ID)
+    end
+
+    # ⚠ prune の日次ジョブは**無タグ**。「全部 unschedule」をやると巻き添えで消える。
+    def test_reload_keeps_untagged_maintenance_job
+      @scheduler.send(:schedule_maintenance)
+      untagged = @scheduler.scheduler.jobs.reject {|v| v.tags.any?}
+
+      assert_not_empty(untagged)
+      # ⚠ 差分が無いと unschedule 自体が走らない。追加と変更の両方を起こしてから見る。
+      write_fixture(OTHER_ID, {})
+      write_fixture(FIXTURE_ID, {'schedule' => {'every' => '2d'}})
+      @scheduler.reload
+
+      assert_equal(untagged.map(&:job_id).sort,
+        @scheduler.scheduler.jobs.reject {|v| v.tags.any?}.map(&:job_id).sort)
+    end
+
+    # ⚠ IcalendarSource は remind と本体の 2 本を同じ tag で登録する。
+    # job id を控える設計にすると remind ジョブが取り残される。
+    def test_reload_replaces_both_icalendar_jobs
+      write_ical_fixture('4 0 * * *')
+      @scheduler.reload
+
+      assert_equal(2, jobs(ICAL_ID).size)
+      before = jobs(ICAL_ID).map(&:job_id)
+      write_ical_fixture('5 0 * * *')
+      @scheduler.reload
+
+      assert_equal(2, jobs(ICAL_ID).size)
+      assert_empty(jobs(ICAL_ID).map(&:job_id) & before)
+    end
+
+    # 🔴 壊れた定義を掴んだら、ジョブは 1 本も触らずに古い定義のまま走り続ける。
+    def test_reload_keeps_jobs_when_config_is_broken
+      job = jobs(FIXTURE_ID).first
+      File.write(fixture_path(BROKEN_ID), "source:\n  feed: \"unterminated\n")
+
+      assert_raise(Psych::SyntaxError) {@scheduler.reload}
+      assert_equal(1, jobs(FIXTURE_ID).size)
+      assert_equal(job.job_id, jobs(FIXTURE_ID).first.job_id)
+    end
+
+    private
+
+    def write_ical_fixture(cron)
+      File.write(fixture_path(ICAL_ID), YAML.dump({
+        'source' => {'ical' => 'https://example.com/calendar.ics'},
+        'schedule' => {'cron' => cron, 'remind' => {'enable' => true}},
+        'dest' => {'hooks' => ["https://example.com/#{ICAL_ID}/hook"]},
+      }))
+    end
+  end
+end

--- a/test/scheduler_daemon.rb
+++ b/test/scheduler_daemon.rb
@@ -8,7 +8,47 @@ module TomatoShrieker
 
     def teardown
       FileUtils.rm_f(@path)
+      @daemon.instance_variable_get(:@reload_queue)&.close
+      @daemon.instance_variable_get(:@reload_thread)&.join(5)
+      trap('HUP', 'DEFAULT')
+      @stubbed&.singleton_class&.remove_method(:reload)
       super
+    end
+
+    # #1459: SIGHUP でソース定義を読み直す。
+    # ⚠ **trap 文脈では Mutex を取れない**（`ThreadError`）。`Scheduler#reload` は
+    # Mutex を取るので、trap は Queue に積むだけにして専用スレッドが処理する。
+    # ここで確かめているのは「HUP がワーカー経由で reload に届く」配線。
+    def test_reload_worker_handles_sighup
+      calls = Thread::Queue.new
+      stub_reload {calls.push(:called)}
+      @daemon.send(:start_reload_worker)
+      Process.kill('HUP', Process.pid)
+
+      assert_equal(:called, calls.pop(timeout: 10))
+    end
+
+    # 🔴 **reload の失敗で daemon を落とさない。**壊れた YAML を掴んだだけなら
+    # 古い定義のまま走り続けるのが正しく、次の reload 要求も処理できねばならない。
+    def test_reload_worker_survives_error
+      calls = Thread::Queue.new
+      stub_reload do
+        calls.push(:called)
+        raise 'boom'
+      end
+      @daemon.send(:start_reload_worker)
+      queue = @daemon.instance_variable_get(:@reload_queue)
+      queue.push(true)
+
+      assert_equal(:called, calls.pop(timeout: 10))
+      queue.push(true)
+
+      assert_equal(:called, calls.pop(timeout: 10))
+    end
+
+    def stub_reload(&)
+      @stubbed = Scheduler.instance
+      @stubbed.define_singleton_method(:reload, &)
     end
 
     def migration_dir


### PR DESCRIPTION
Closes #1459

設計は [issue のコメント](https://github.com/pooza/tomato-shrieker/issues/1459#issuecomment-) で 2026-08-25 に合意したとおり。前提の `Config#load` 修正（手順 1）は #1530 で 4.7.0 に入っている。⚠ **依存していた #1503（稼働中のソースを disable にすると恒久 503）は PR #1544 で解消済み。**

## 何ができるようになったか

```sh
$ bin/shrieker source disable foo
disabled: foo
⚠ 稼働中の scheduler に反映するには bin/shrieker source reload

$ bin/shrieker source reload
reload requested (pid 1322485)
  結果はログの {"scheduler":"reload",...} 行で確認できます。
```

- `source reload` が `tmp/pids/SchedulerDaemon.pid` を読んで **SIGHUP** を送る
- daemon は trap で Queue に積み、**専用スレッド**が `Scheduler#reload` を呼ぶ。⚠ **trap 文脈では Mutex を取れない**（`ThreadError`）
- ⚠ **`:unknown`（EPERM）を `:dead` と混ぜない。**停止中は「次回起動時に読まれます」と言って正常終了、触れない pid はエラー

## 差分適用

id 単位で設定の digest を持ち、**無変更のソースはジョブに触らない**。

- 🔴 **全件を貼り替えてはいけない。**`every` は差し替えると**次回発火が 1 周期先へずれる**ので、全件貼り替えは 39 ソース全部の位相をリセットする
- 🔴 **消すのは job id ではなく tag。**`IcalendarSource#register` は remind と本体の **2 本を同じ `tag: id`** で登録し、`register` の戻り値は本体ぶんだけ
- ⚠ `schedule_maintenance`（prune）の日次ジョブは**無タグ**なので巻き添えにしない
- ⚠ **実行中の run は殺さない**（`unschedule` は以後の発火を止めるだけ）＝仕様として docs に書いた
- 🔴 **壊れた YAML を掴んだら設定もジョブも変えない**（#1530 の `Config#load` が読み切ってから 1 回で差し替えるため）
- ⚠ **reload ではスキーマ検証をしない**（起動時が検証していない以上、reload だけ厳しいと「起動はできるのに reload は拒否される」定義が生まれる）

## 却下したもの（設計どおり）

- **自動 reload** — `source add` は $EDITOR を開く**前に**スキーマ妥当な雛形を書くので、ファイル監視だと `example.com` へ投げるジョブが即座に立つ
- **監視エンドポイントに `POST /reload`** — 読み取り専用だった監視面が制御面になる

## スコープ外

- **`application.yaml` / `local.yaml` の reload** — `Ginseng::Config#load` は一度読んだファイルを二度と読まない。**仕様として維持**し、コマンド名を `source reload` にして範囲を名詞で言い切った
- **結果の同期受け取り** — #1529
- **上流 (`ginseng-core`) への `trap('HUP')` 持ち込み** — まず tomato で動かしてから

## その他

`SourceCommand` が `Metrics/ClassLength` を超えたので、`add --class` の雛形を `SourceTemplates` へ切り出しました（振る舞いの変更なし）。

## 確認したこと

- `bundle exec rake test`: **250 tests, 930 assertions, 0 failures, 0 errors**
- `bundle exec rubocop`: **94 files inspected, no offenses detected**
- `bin/shrieker source reload`（daemon 停止中）が「次回起動時に読み込まれます」を返して正常終了することを実機で確認
- ⚠ **4 つの変異を入れて、対応するテストが落ちることを確認**（全件貼り替え / 全ジョブ unschedule / tag の 1 本目だけ unschedule / `trap('HUP')` と worker の `rescue` の除去）
- 🔴 **本番の実機検証はこれから**（daemon を再起動して SIGHUP を打つ必要があるため、リリース前検証で行う）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcksxjVq8KutvzojvQ8rxt