### PR TITLE
fix: 未回収だった Codex 指摘 3 件を回収する (#1548 / #1549 / #1550)

### DIFF
--- a/app/lib/tomato_shrieker/config.rb
+++ b/app/lib/tomato_shrieker/config.rb
@@ -21,10 +21,29 @@ module TomatoShrieker
     #
     # ⚠ `+` で新しい配列を作る。`super` が返す配列は `@raw` の実体そのものなので、
     # そこへ push すると load のたびに積み増さる（ginseng-core#491）。
+    # ⚠ **公開は 1 手にする (#1548)。**`super` は self を直接 `update` するので、
+    # そのままだと `/sources` が `application.yaml` の値（＝ `[]`）へ戻り、
+    # **完成するまでの間、読み手には空の一覧が見える**。⚠ 窓を短くしても消えない。
+    # `update` を横流しして完成品を組み立て、**1 回の `replace`** で公開する
+    # （MRI の `Hash#replace` は C で完結するので中間状態が見えない）。
     def load
       entries = source_entries
-      super
-      self['/sources'] = self['/sources'] + entries
+      @staging = {}
+      begin
+        super
+        staged = @staging
+        staged['/sources'] = (staged['/sources'] || []) + entries
+      ensure
+        @staging = nil
+      end
+      replace(staged)
+    end
+
+    # ⚠ `load` の最中だけ横流しする。ここを素通しにすると `super` が self を
+    # 書き換え、上の「公開は 1 手」が崩れる。
+    def update(other)
+      return @staging.update(other) if @staging
+      return super
     end
 
     # `config/sources/*.yaml` を読んで配列にする。⚠ self には触らない。

--- a/app/lib/tomato_shrieker/sentry_scrubber.rb
+++ b/app/lib/tomato_shrieker/sentry_scrubber.rb
@@ -55,6 +55,24 @@ module TomatoShrieker
     # ⚠ ログ自体が落ちても before_send を巻き込まない（イベントは落とす側に倒す）。
     def report_drop(error)
       @logger.error(sentry: 'before_send', message: 'event dropped (scrub failed)', error:)
+    rescue StandardError => e
+      report_drop_fallback(error, e)
+    end
+
+    # 🔴 **報告の最後の 1 手はマスク経路に依存させない (#1549)。**
+    # scrub が落ちる原因がマスク設定そのものなら、`@logger.error` も同じ理由で
+    # 落ちる。⚠ そこを黙って捨てると「**Sentry へ 1 件も届かないのに、どこにも
+    # 何も出ない**」＝ #1467 が塞ごうとした状態に戻る。
+    #
+    # ⚠ **出すのは例外のクラス名だけ。**メッセージを載せると、伏せるはずだった
+    # 値をマスク無しで書くことになる。
+    # ⚠ **`warn` は使えない。**`bin/scheduler_daemon.rb` が
+    # `$stderr.reopen(File::NULL)` するので本番では丸ごと消える。
+    def report_drop_fallback(error, log_error)
+      ::Syslog::Logger.new(Package.name).error(
+        'sentry before_send: event dropped (scrub failed):' \
+          " #{error.class} (logging failed: #{log_error.class})",
+      )
     rescue StandardError
       return nil
     end

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -785,12 +785,16 @@ Nostr 対応は外部ユーザーのリクエストで実装された機能。�
 
 ⚠ **サテライト 3 本（`loquat` / `shooby-do-bop` / `dqdai-anniv`）も対象。**本体だけ追随すると CommandSource の 7 ソースだけ古い gem で動き続ける。
 
-🔴 **作業ツリーの `Gemfile.lock` を読んではいけない。**チェックアウトが古い feature ブランチに乗っていると、**そのブランチのピンを現状と誤読する**。2026-08-25 の sync では、サテライト 3 本が `chore/*-ginseng-style` に乗っていたせいで **ahead=103（実際は 21）** と出て、追随済みのものを未追随と誤判定しかけた。**必ず `origin/HEAD` から取り出す。**
+🔴 **tomato 自身は `origin/develop` から読む (#1550)。**⚠ **`origin/HEAD` は `main` ＝ リリース済みの版**で、日常の作業は `develop`。main と develop でピンが違う期間、`origin/HEAD` を読むと**すでに `develop` で追随済みのものをもう一度上げようとするか、`develop` 側の乖離を見落とす**。⚠ **サテライト 3 本はそれぞれの default ブランチのまま**（`shooby-do-bop` は `master`）。
+
+🔴 **作業ツリーの `Gemfile.lock` を読んではいけない。**チェックアウトが古い feature ブランチに乗っていると、**そのブランチのピンを現状と誤読する**。2026-08-25 の sync では、サテライト 3 本が `chore/*-ginseng-style` に乗っていたせいで **ahead=103（実際は 21）** と出て、追随済みのものを未追随と誤判定しかけた。**必ず追跡ブランチから取り出す**（上記のとおり tomato は `origin/develop`、サテライトは `origin/HEAD`）。
 
 ```sh
 for d in tomato-shrieker loquat shooby-do-bop dqdai-anniv; do
+  # ⚠ tomato 自身だけ develop。origin/HEAD は main ＝ リリース済みの版 (#1550)
+  ref=origin/HEAD; [ "$d" = tomato-shrieker ] && ref=origin/develop
   git -C ~/repos/$d fetch -q origin
-  git -C ~/repos/$d show origin/HEAD:Gemfile.lock |
+  git -C ~/repos/$d show $ref:Gemfile.lock |
   awk '/github\.com\/pooza\/ginseng-/{g=$2; sub(/.*\//,"",g); sub(/\.git/,"",g); f=1} f&&/revision:/{print g, $2; f=0}' |
   while read -r gem rev; do
     ahead=$(gh api repos/pooza/$gem/compare/$rev...main --jq .ahead_by 2>/dev/null)

--- a/test/config.rb
+++ b/test/config.rb
@@ -35,6 +35,29 @@ module TomatoShrieker
       assert_equal([expected], observed.uniq, "reload の途中経過が見えている: #{observed.uniq.sort}")
     end
 
+    # 🔴 #1548: 公開は 1 手。⚠ **上のサンプリングでは窓を取りこぼしうる**ので、
+    # 「公開の直前まで self が触られていないこと」を決定的に見る。
+    # `super` が self を `update` する実装だと、この時点で `/sources` は
+    # `application.yaml` の値（＝空）へ戻っている。
+    def test_load_does_not_touch_self_until_publish
+      write_sources(3)
+      config.reload
+      expected = config['/sources'].size
+      seen = nil
+      config.define_singleton_method(:replace) do |hash|
+        seen = self['/sources'].size
+        super(hash)
+      end
+      begin
+        config.reload
+      ensure
+        config.singleton_class.remove_method(:replace)
+      end
+
+      assert_equal(expected, seen, '公開の前に self が書き換わっている')
+      assert_equal(expected, config['/sources'].size)
+    end
+
     # 🔴 #1530: 壊れた YAML があっても、それまでの内容を壊さないこと。
     #
     # 以前は 3 件目で raise すると 2 件目まで積まれた状態で残った。⚠ ソース定義を

--- a/test/sentry_scrubber.rb
+++ b/test/sentry_scrubber.rb
@@ -88,6 +88,46 @@ module TomatoShrieker
       assert_equal('before_send', logged.first[:sentry])
     end
 
+    # 🔴 **logger 自身が落ちても、どこかへ残すこと (#1549)。**
+    # scrub が落ちる原因がマスク設定そのものなら、報告に使う `@logger.error` も
+    # 同じ理由で落ちる。⚠ そこで黙ると「**Sentry へ 1 件も届かないのに、どこにも
+    # 何も出ない**」＝ #1467 が塞ごうとした状態に戻る。マスク経路に依存しない
+    # sink（素の `Syslog::Logger`）へ、例外のクラス名だけを出す。
+    def test_scrub_reports_drop_when_logger_fails
+      event = error_event(StandardError.new('boom'))
+      event.define_singleton_method(:extra) {raise 'boom'}
+      @scrubber.instance_variable_get(:@logger).define_singleton_method(:error) {|_arg| raise 'logger boom'}
+      fallback = []
+      @scrubber.define_singleton_method(:report_drop_fallback) do |error, log_error|
+        fallback.push([error.class, log_error.class])
+      end
+
+      @scrubber.scrub(event)
+
+      assert_equal(1, fallback.size, 'logger が落ちたときに何も残っていない')
+    end
+
+    # ⚠ 予備の sink は「マスク経路を通らないこと」と「クラス名しか出さないこと」
+    # の両方が要る。⚠ **メッセージを載せると、伏せるはずだった値が素で出る。**
+    def test_report_drop_fallback_emits_class_names_only
+      written = []
+      logger = Object.new
+      logger.define_singleton_method(:error) {|arg| written.push(arg)}
+      Syslog::Logger.define_singleton_method(:new) {|*| logger}
+      begin
+        @scrubber.send(:report_drop_fallback,
+          Ginseng::GatewayError.new(WEBHOOK_URL), RuntimeError.new(FEED_TOKEN))
+      ensure
+        Syslog::Logger.singleton_class.remove_method(:new)
+      end
+
+      assert_equal(1, written.size)
+      assert_include(written.first, 'Ginseng::GatewayError')
+      assert_include(written.first, 'RuntimeError')
+      assert_not_include(written.first, WEBHOOK_DIGEST)
+      assert_not_include(written.first, FEED_TOKEN)
+    end
+
     # ⚠ ログ自体が落ちても before_send を巻き込まないこと。
     def test_scrub_survives_logger_failure
       event = error_event(StandardError.new('boom'))


### PR DESCRIPTION
Closes #1548
Closes #1549
Closes #1550

`pulls/comments` をリポジトリ全体で走査したところ、**返信も 👍 / 👎 も無い Codex 指摘が 2026-08-25 の 3 件（P1 × 2 / P2 × 1）残っていました**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md) の「取り残さない」）。3 件とも成立したので Issue に切って直します。

## #1548 (P1・PR #1534 由来): ソース一覧の公開が 2 手

`Config#load` は #1530 で「読み切ってから差し替える」形にしましたが、**公開そのものは 2 手のまま**でした。`super` が `/sources` を `application.yaml` の値（＝ `[]`）へ戻し、次の行で初めて完成します。⚠ **その間に走った読み手は空の一覧を観測できる** ＝ `/healthz/source/:id` が偽の 404、`/status.json` はソースが欠けて見える。

🔴 **窓を短くしても消えません。**⚠ そして **#1459 で reload が稼働中の操作になった**ので、ここは実際に踏みうる場所になりました。

`update` を load の間だけ横流しして完成品を組み立て、**1 回の `replace`** で公開します（MRI の `Hash#replace` は C で完結するので中間状態が見えない）。⚠ **サンプリングのテストは窓を取りこぼしうる**という指摘に対応して、**決定的なテスト**（公開の直前まで self が触られていないこと）を足しました。

## #1549 (P1・PR #1539 由来): 落としたことの報告が、壊れているのと同じ logger を通る

`SentryScrubber` は fail closed で、マスクを通せなかったイベントを落として報告します。⚠ **その報告が、落ちた原因と同じマスク経路を通っていました。**マスク設定自体が壊れていれば `@logger.error` も同じ理由で落ち、`rescue` が黙って捨てる ＝ 🔴 **Sentry へ 1 件も届かないのに、どこにも何も出ない**（#1467 が塞ごうとした状態そのもの）。

最後の 1 手だけ**マスク経路に依存しない sink**（素の `Syslog::Logger`）へ倒しました。⚠ **出すのは例外のクラス名だけ**（メッセージを載せると、伏せるはずだった値をマスク無しで書くことになる）。⚠ `warn` は使えません（`bin/scheduler_daemon.rb` が `$stderr.reopen(File::NULL)` する）。

## #1550 (P2・PR #1525 由来): sync が tomato 自身のピンを main から読む

`origin/HEAD` は `main` ＝ リリース済みの版ですが、日常の作業は `develop` です。⚠ 手順とサンプルスクリプトの両方を直しました。サテライト 3 本はそれぞれの default ブランチのまま。

## 確認したこと

- `bundle exec rake test`: **253 tests, 938 assertions, 0 failures, 0 errors**
- `bundle exec rubocop`: **94 files inspected, no offenses detected**
- ⚠ **2 つの P1 とも、旧実装へ戻すと対応テストが落ちることを確認**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcksxjVq8KutvzojvQ8rxt