### PR TITLE
chore: ginseng-core を 1.23.5 に追随する

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,28 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
-  revision: 430ad064e94c3e8cea53cd1d5d8b3b4b32a723dc
+  revision: d53a18b5c74d13af6b78b6a7ae6e0c6a7a0caa88
   branch: main
   specs:
-    ginseng-core (1.22.0)
-      activesupport (>= 7.0.7.1)
+    ginseng-core (1.23.5)
+      activesupport (>= 8.1.2.1)
       addressable (>= 2.9.0)
       cgi (>= 0.4.2)
       csv
       date (>= 3.2.1)
-      erb
+      erb (>= 6.0.4)
       etc
       facets
       fileutils (~> 1.7.0)
       find
       httparty (>= 0.24.0)
       json-schema
-      mail
+      mail (>= 2.5.5)
       multi_json
       net-protocol
       net-smtp
-      nokogiri (>= 1.18.9)
+      nokogiri (>= 1.19.4)
       optparse
-      rake (!= 13.4.0)
+      rake (>= 12.3.3, != 13.4.0)
       sanitize (>= 6.0.2)
       securerandom
       set
@@ -30,18 +30,18 @@ GIT
       time (>= 0.2.2)
       yajl-ruby (>= 1.4.3)
       zeitwerk (>= 2.4.0)
-      zlib
+      zlib (>= 3.2.3)
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 8b23e095d68674d18840ea782c15c560202f3adb
+  revision: 8d6d1fa6f9e49f71347cd3b47eea794f12ae8f45
   branch: main
   specs:
     ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: 1150891191edb02dbbc60153a375b1756b0bd943
+  revision: afddcdace7ae524cfba4967e5f7de97637bbea32
   branch: main
   specs:
     ginseng-piefed (0.1.1)
@@ -59,10 +59,10 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: f041de996b98a6d24df07c5fcd70893290206f68
+  revision: 71415a45d291f7a823e1b51c397e4651d9625237
   branch: main
   specs:
-    ginseng-youtube (2.0.1)
+    ginseng-youtube (3.0.1)
 
 GIT
   remote: https://github.com/pooza/icalendar-rrule.git
@@ -173,7 +173,7 @@ GEM
       net-protocol
     net-pop (0.1.2)
       net-protocol
-    net-protocol (0.2.2)
+    net-protocol (0.3.0)
       timeout
     net-smtp (0.5.1)
       net-protocol


### PR DESCRIPTION
## 何をしたか

`Gemfile.lock` の ginseng-* のピンを追随した。**`ginseng-core` が 30 コミット遅れていた**（1.22.0 → 1.23.5）。

| gem | 前 | 後 |
| --- | --- | --- |
| ginseng-core | 1.22.0 (`430ad06`) | **1.23.5** (`d53a18b`) |
| ginseng-youtube | 2.0.1 (`f041de9`) | **3.0.1** (`71415a4`) |
| ginseng-fediverse | `8b23e09` | `8d6d1fa` |
| ginseng-piefed | `1150891` | `afddcda` |
| net-protocol | 0.2.2 | 0.3.0 |

## なぜ溜まっていたか

sync 手順の ginseng ピン棚卸しが `origin/HEAD`（＝ `main` ＝ リリース済み）を読んでいて、日々の作業ブランチである `develop` を見ていなかった（#1550・#1551 で修正済み）。今回はその直した手順で拾えた。

## 中身

⚠ **大半が資格情報マスクの修正で、tomato に直接効く**（#1467 / #1522 の続き）。

- `mask_fields` の既定を広げ、設定とは合成する（pooza/ginseng-core#586）
- URL の userinfo のパスワードをマスクする（#589）
- **IPv6 リテラル / zone id 付き URL がマスクを素通りしていた**（#601 / #609）
- `mask_urls_in` が不正なバイト列・ASCII 非互換エンコーディングで落ちる（#587 / #591）
- マスクの判定がキーの大文字小文字を区別する（pooza/makoto2#198）
- **マスクのリストを `Config#reload` に追随させる**（#592）
- `host_validator` を渡しても upload のログの形が変わらない（#578）
- runtime 依存の床を advisory に合わせる（#614）

**`ginseng-youtube` は 3.0.1（major）だが、中身は release workflow の追加と版番号だけで API の変更は無い。**`fediverse` / `piefed` は ginseng-style の追随のみ。

`ginseng-style` は `Gemfile` が `tag: 'v1.1.12'` で固定しているので動かない。⚠ **棚卸しスクリプトは `main` と比べるので「3 コミット遅れ」と出るが、これは遅れではなくタグより main が先へ進んでいるだけ。**

## 📌 #1538 はこの追随で解消した可能性が高い

[#1538](https://github.com/pooza/tomato-shrieker/issues/1538)（`SentryScrubber` だけ `Config#reload` が効かない）の**案 2「`Ginseng::Masking` の memo を config の世代で無効化する」を上流が #592 で入れていた**。memo の鍵が合成後ではなく設定そのものになっている。

実測（このブランチ・`SentryScrubber` が握っている Logger インスタンスをそのまま使用）:

```
config[/logger/mask_fields] = ["secret_probe"]
before: {secret_probe: "S3CRET"}   # reload 前
after : {}                         # reload 後 = 反映された
```

⚠ **確認テストを足してから閉じること。**この PR には含めていない。

## 検証

- `rake test` **250 tests / 1 failures**。落ちたのは `FeedSourceTest#test_entries` で、**上流の Google ニュース RSS が「プリキュア」に item 0 件を返す**のが原因（この追随とは無関係。同時刻に「天気」は 100 件返り、本番 `precure-google-news` は直前に配信できている）
- ⚠ `test_prune_keeps_first_run_row` が 1 回落ちたが再実行 2 回とも緑。`Time.now` を挿入時と assert 時の 2 回呼んで `.to_i` を比べており、秒境界をまたぐと落ちる**既存のフレーク**（この追随とは無関係）
- ⚠ **本番での挙動観察が要る**（溜めてから一気に追随したため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Kr4DTayTwWiN2tUAtiPXA
