### PR TITLE
fix: 未達の 503 に失敗の理由を出す (#1507)

### DIFF
--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -86,9 +86,27 @@ module TomatoShrieker
       body << "grace_seconds: #{source.monitor_grace_seconds}\n"
       body << "stale: #{checks[:stale]}\n"
       body << "error_streak: #{checks[:streak]}\n"
-      body << "error: #{latest.error_message}\n" if latest.error?
-      body << undelivered_body(checks[:undelivered]) if checks[:undelivered]&.undelivered?
+      body << failure_body(latest)
+      body << undelivered_body(checks[:undelivered], latest) if checks[:undelivered]&.undelivered?
       body << silent_body(source) if checks[:silent]
+      return body
+    end
+
+    # 🔴 **失敗の理由は status に関係なく出す (#1507)。**
+    #
+    # 以前は `latest.error?`（＝ `status == "error"`）でだけ出していた。⚠ #1482 で
+    # `partial` を分けた時点で、**Matrix 配信停止 (#1455) と同じ形の run は
+    # `partial` になり、理由がまったく出ない 503** になっていた（v4.5.0 からの後退）。
+    # `record_partial` は「status が error でないだけで、失敗は失敗として読める
+    # ようにする」ために `error_message` を残しているので、それを出す。
+    #
+    # ⚠⚠ **宛先ごとの識別子は出さない。**webhook の URL はパスそのものが資格情報
+    # (#1467)。`shrieker_errors` なら宛先の**種別**までは絞れて、識別子は載らない。
+    def failure_body(log, prefix = '')
+      body = +''
+      body << "#{prefix}error: #{log.error_message}\n" if log.error_message.present?
+      errors = log.shrieker_error_counts
+      body << "#{prefix}shrieker_errors: #{JSON.dump(errors)}\n" if errors.any?
       return body
     end
 
@@ -110,12 +128,18 @@ module TomatoShrieker
 
     # #1504: 「いつ・何件のうち何件が届かなかったか」を運用者に見せる。
     # ⚠ 宛先の識別子は持たないので「どの宛先か」は出せない。設定を見て切り分ける。
-    def undelivered_body(log)
+    def undelivered_body(log, latest)
       # ⚠ 式展開の無いリテラルなので `+` で可変にする (#1512)。上の silent_body 参照。
       body = +"undelivered: true\n"
       body << "last_attempted_at: #{log.executed_at.iso8601}\n"
       body << "attempted_count: #{log.attempted_count}\n"
       body << "delivered_count: #{log.delivered_count}\n"
+      # 🔴 **no-op を挟むと `latest` は success の no-op 行になる (#1507)。**
+      # そのとき理由を持っているのは `latest` ではなく「直近の配信試行」の行なので、
+      # ここでも出す。⚠ 同じ行なら上の failure_body と重複するので出さない。
+      return body if log.id == latest.id
+      body << "last_attempted_status: #{log.status}\n"
+      body << failure_body(log, 'last_attempted_')
       return body
     end
 

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -363,6 +363,32 @@ module TomatoShrieker
       assert_include(body.first, 'delivered_count: 1')
     end
 
+    # 🔴 **理由の無い 503 を運用者に見せない (#1507)。**
+    # #1482 で `partial` を分けてから、`error:` 行の条件が `status == "error"` の
+    # ままだったので、**#1455 の形の 503 は本文に理由がゼロ**になっていた。
+    # ⚠ v4.5.0 では出ていた＝後退。
+    def test_healthz_source_undelivered_shows_reason
+      record(FIXTURE_ID, status: SourceRunLog::STATUS_PARTIAL, attempted_count: 2,
+        delivered_count: 1, error_message: 'RuntimeError: boom',
+        shrieker_errors: JSON.dump('WebhookShrieker' => 1))
+      _status, _headers, body = call("/healthz/source/#{FIXTURE_ID}")
+
+      assert_include(body.first, 'RuntimeError: boom', '理由の無い 503 になっている')
+      # 宛先の**種別**までは絞れる。⚠ 識別子は載せない (#1467)
+      assert_include(body.first, 'shrieker_errors: {"WebhookShrieker":1}')
+    end
+
+    # ⚠ 同じ行を 2 度出さない。latest が直近の配信試行そのものなら
+    # `last_attempted_error:` は要らない。
+    def test_healthz_source_undelivered_reason_is_not_duplicated
+      record(FIXTURE_ID, status: SourceRunLog::STATUS_PARTIAL, attempted_count: 2,
+        delivered_count: 1, error_message: 'RuntimeError: boom')
+      _status, _headers, body = call("/healthz/source/#{FIXTURE_ID}")
+
+      assert_not_include(body.first, 'last_attempted_error:')
+      assert_equal(1, body.first.scan('RuntimeError: boom').size)
+    end
+
     # 全宛先へ届いた run が来たら解除する
     def test_healthz_source_undelivered_recovers
       record(FIXTURE_ID, status: SourceRunLog::STATUS_PARTIAL, attempted_count: 2,
@@ -383,6 +409,22 @@ module TomatoShrieker
 
       assert_equal(503, status)
       assert_include(body.first, 'undelivered: true')
+    end
+
+    # 🔴 **no-op を挟むと `latest` は success の no-op 行になる (#1507)。**
+    # そのとき `status: success` ＋ `undelivered: true` だけが出て、**理由が
+    # どこにも無い 503** になっていた。理由を持っているのは「直近の配信試行」の行。
+    def test_healthz_source_undelivered_shows_reason_after_noop
+      record(FIXTURE_ID, status: SourceRunLog::STATUS_PARTIAL, attempted_count: 2,
+        delivered_count: 1, error_message: 'RuntimeError: boom',
+        shrieker_errors: JSON.dump('WebhookShrieker' => 1), at: Time.now - 120)
+      record(FIXTURE_ID, attempted_count: 0, at: Time.now)
+      _status, _headers, body = call("/healthz/source/#{FIXTURE_ID}")
+
+      assert_include(body.first, 'status: success', '前提: latest は no-op の success 行')
+      assert_include(body.first, 'last_attempted_status: partial')
+      assert_include(body.first, 'last_attempted_error: RuntimeError: boom')
+      assert_include(body.first, 'last_attempted_shrieker_errors: {"WebhookShrieker":1}')
     end
 
     # 一度も配信を試みていないソースを未達扱いしない


### PR DESCRIPTION
Closes #1507

## 何が壊れていたか

`/healthz/source/:id` の 503 本文で `error:` を出す条件が **`latest.error?`（＝ `status == "error"`）** だった。⚠ #1482 で `partial` を分けた時点から、**Matrix 配信停止 (#1455) と同じ形の run は `partial` になるので `error?` は false**。

結果、再現した 503 の本文はこれだけになっていた。

```
status: partial
undelivered: true
attempted_count: 2
delivered_count: 1
```

`record_partial` がわざわざ残した `error_message` も `shrieker_errors` も出ない。**v4.5.0 ではこの run は `error` だったので出ていた ＝ 後退。**

さらに no-op を挟むと `latest` は success の no-op 行になるので、**`status: success` ＋ `undelivered: true` だけの、理由がゼロの 503** になる。

## 直し方

1. **失敗の理由は status に関係なく出す。**`error_message` があれば出す（`failure_body`）
2. **`shrieker_errors` も出す。**⚠ **宛先ごとの識別子は出さない方針は維持**（webhook の URL はパスそのものが資格情報・#1467）。種別までは絞れる
3. **no-op を挟んだ場合は「直近の配信試行」の行から出す**（`last_attempted_status` / `last_attempted_error` / `last_attempted_shrieker_errors`）。⚠ `latest` と同じ行なら重複させない

### 出力例（no-op を挟んだ場合）

```
status: success
executed_at: ...
undelivered: true
last_attempted_at: ...
attempted_count: 2
delivered_count: 1
last_attempted_status: partial
last_attempted_error: RuntimeError: boom
last_attempted_shrieker_errors: {"WebhookShrieker":1}
```

## テスト

3 件追加。**fix を外すと 3 件とも赤くなることを確認済み**（`264 tests, 3 failures`）。

- `test_healthz_source_undelivered_shows_reason` — partial の理由と種別が出る
- `test_healthz_source_undelivered_shows_reason_after_noop` — no-op を挟んでも理由が出る
- `test_healthz_source_undelivered_reason_is_not_duplicated` — 同じ行を 2 度出さない

`264 tests, 964 assertions, 0 failures, 0 errors` / rubocop clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX8ptAvq1svHGBCFcZFCHM