### PR TITLE
fix: fetch 経路の失敗チャンネルを既存と対称にする (#1485)

### DIFF
--- a/app/lib/tomato_shrieker/source/feed_source.rb
+++ b/app/lib/tomato_shrieker/source/feed_source.rb
@@ -2,6 +2,15 @@ require 'feedjira'
 
 module TomatoShrieker
   class FeedSource < Source
+    # 配信まで到達せずに落ちたエントリを `shrieker_errors` に積むときのキー (#1485)。
+    #
+    # ⚠⚠ **`self.class` を使わない。**以前は `"#{self.class}#fetch"` だったので
+    # `TomatoShrieker::GoogleNewsSource#fetch` / `...YouTubeChannelSource#fetch` と
+    # **サブクラスの数だけキーが増え**、宛先別の分布（`MastodonShrieker` 等）と
+    # 同じ Hash に足し込まれて `/status.json` が読めなくなっていた。
+    # ⚠ ソース ID は run_log の行が持っているので、クラス名は冗長。
+    FETCH_FAILURE_KIND = 'source#fetch'.freeze
+
     def initialize(params)
       super
       @http = HTTP.new
@@ -108,10 +117,20 @@ module TomatoShrieker
         next unless record = create_record(entry)
         yield record
       rescue => e
-        logger.error(source: id, error: e)
         # create_record / create_template / enclosures 由来の失敗は Entry#shriek に
         # 到達しないので、ここで計上しないと run が no-op success になる (#1473)。
-        @delivery_stats&.record_failure("#{self.class}#fetch", e)
+        #
+        # ⚠⚠ **計上を先に打つ (#1485)。**この rescue で `/healthz` を赤にできるのは
+        # run_log への計上だけで、Sentry と logger は報告でしかない。報告を先に打つと、
+        # 壊れた例外メッセージ（#1469 の族）でそこが落ちたときに **失敗がまったく
+        # 計上されず run が no-op success に戻る**＝ #1473 が塞いだ穴が開き直す。
+        @delivery_stats&.record_failure(FETCH_FAILURE_KIND, e)
+        # 🔴 **`/healthz` を 503 にするのに Sentry へ出ないエラーを作らない (#1485)。**
+        # 既存の失敗チャンネル（`Source#shriek` の shrieker 失敗、run 全体の例外）は
+        # 送っているのに、4.5.0 で新設したこの経路だけ送っていなかった。
+        # ⚠ シークレットは `SentryScrubber` が落とす (#1467)。
+        Sentry.capture_exception(e, tags: {source: id, stage: 'fetch'}) if Sentry.initialized?
+        logger.error(source: id, error: e)
       end
     end
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -430,6 +430,8 @@ monitor:
 - `source_id`, `executed_at`, `status` (`success` | `partial` | `error`), `error_message`, `duration_ms`
 - `attempted_count` / `delivered_count` — その run で配信を試みた件数 / 実際に配信できた件数
 - `shrieker_errors` — shrieker (投稿先) 別のエラー件数を JSON で保持（例: `{"MastodonShrieker":2}`）。エラーが無ければ `NULL`
+  - ⚠ **shrieker クラス名以外の値も入る。**宛先に一度も触れていない失敗はここへ **`UnavailableDest`**（設定はあるが Shrieker を組み立てられなかった宛先・#1504）や **`source#fetch`**（配信手前でエントリが落ちた・#1473 / #1485）として積まれる。**「どの宛先が失敗したか」と「どの処理段階が失敗したか」が同じ Hash に混在する**ので、集計を読むときは区別すること
+  - 🔴 **古い行には `TomatoShrieker::FeedSource#fetch` のような旧キーが残っている。**#1485 でクラス名依存をやめて `source#fetch` に固定したが、それ以前の行はそのまま
 - 古いレコードは Rufus ジョブで毎日 prune（`/monitor/retention_days`）
 
 計上は `Source#shriek` の各 shrieker 呼び出し単位で行い、`DeliveryStats` が Mutex 越しに集約する（`IcalendarSource#exec` は `Parallel.each` で並列配信するため）。

--- a/test/feed_source.rb
+++ b/test/feed_source.rb
@@ -1,5 +1,8 @@
 module TomatoShrieker
   class FeedSourceTest < TestCase
+    FIXTURE_ID = '__test_feed_source__'.freeze
+    SENTRY_STUBBED = [:initialized?, :capture_exception].freeze
+
     def test_all
       assert_kind_of(Enumerator, FeedSource.all)
     end
@@ -86,6 +89,84 @@ module TomatoShrieker
       FeedSource.all do |source|
         assert_kind_of(String, source.prefix)
       end
+    end
+
+    # 🔴 **`shrieker_errors` のキーをクラス名に依存させない (#1485)。**
+    # 以前は `"#{self.class}#fetch"` だったのでサブクラスごとにキーが増え、宛先別の
+    # 分布（`MastodonShrieker` 等）と同じ Hash に足し込まれて `/status.json` が
+    # 読めなくなっていた。
+    def test_fetch_failure_kind_is_not_class_dependent
+      stats = DeliveryStats.new
+      [FeedSource, Class.new(FeedSource)].each {|klass| run_failing_fetch(klass, stats)}
+
+      assert_equal({'source#fetch' => 2}, stats.shrieker_errors,
+        'サブクラスごとにキーが増えている')
+    end
+
+    # 🔴 **`/healthz` を 503 にするのに Sentry へ出ないエラーを作らない (#1485)。**
+    # 既存の失敗チャンネル（`Source#shriek` の shrieker 失敗、run 全体の例外）は
+    # 送っているのに、4.5.0 で新設したこの経路だけ送っていなかった。
+    def test_fetch_failure_is_captured_by_sentry
+      captured = []
+      with_sentry_stub(captured) {run_failing_fetch(FeedSource, DeliveryStats.new)}
+
+      assert_equal(1, captured.size, '503 になるのに Sentry へ出ていない')
+      assert_equal('fetch', captured.first[:tags][:stage])
+      assert_equal(FIXTURE_ID, captured.first[:tags][:source])
+    end
+
+    # ⚠⚠ **報告より先に計上する (#1485)。**この rescue で `/healthz` を赤にできるのは
+    # run_log への計上だけ。報告（logger）を先に打つと、壊れた例外メッセージ
+    # （#1469 の族）でそこが落ちたときに **run が no-op success に戻る**
+    # ＝ #1473 が塞いだ穴が開き直す。
+    def test_fetch_failure_is_recorded_before_reporting
+      stats = DeliveryStats.new
+      source = stub_failing(FeedSource.new(fixture_params), stats)
+      source.define_singleton_method(:logger) {raise 'logger boom'}
+      begin
+        source.fetch {|_record| nil}
+      rescue StandardError
+        nil
+      end
+
+      assert_equal({'source#fetch' => 1}, stats.shrieker_errors,
+        '報告が落ちると計上まで落ちている')
+    end
+
+    private
+
+    def fixture_params
+      return {'id' => FIXTURE_ID, 'source' => {'feed' => 'https://example.com/f.rss'}}
+    end
+
+    def run_failing_fetch(klass, stats)
+      stub_failing(klass.new(fixture_params), stats).fetch {|_record| nil}
+    end
+
+    # ⚠ ネットワークへ出ない。`entries` と `create_record` を差し替えて、
+    # 「配信手前でエントリが落ちる」経路だけを通す。
+    def stub_failing(source, stats)
+      source.define_singleton_method(:entries) {|&block| block ? [:entry].each(&block) : [:entry].each}
+      source.define_singleton_method(:ignore_entry?) {|_entry| false}
+      source.define_singleton_method(:create_record) {|_entry| raise 'boom'}
+      source.instance_variable_set(:@delivery_stats, stats)
+      return source
+    end
+
+    # ⚠⚠ **`remove_method` で戻してはいけない。**`Sentry.initialized?` は Sentry 自身の
+    # singleton class に生えているので、`define_singleton_method` は**本物を上書き**する。
+    # `remove_method` すると本物ごと消えて、**以降のテストが軒並み
+    # `NoMethodError: undefined method 'initialized?'` で落ちる**（実際に踏んだ）。
+    # 元の Method を保存して差し戻す。
+    def with_sentry_stub(captured)
+      originals = SENTRY_STUBBED.to_h {|name| [name, Sentry.method(name)]}
+      Sentry.define_singleton_method(:initialized?) {true}
+      Sentry.define_singleton_method(:capture_exception) do |error, **options|
+        captured.push({error:}.merge(options))
+      end
+      yield
+    ensure
+      originals&.each {|name, method| Sentry.define_singleton_method(name, method)}
     end
   end
 end


### PR DESCRIPTION
Closes #1485

4.5.0 で新設した `FeedSource#fetch` の失敗チャンネルが、既存の失敗チャンネルと非対称になっていた。

## 1. Sentry へ送っていなかった

⚠ **「`/healthz` を 503 にするのに Sentry にイシューが立たないエラー」が存在していた。**`Source#shriek` の shrieker 失敗も run 全体の例外も送っているのに、この経路だけ送っていない。

既存と同等のタグで送るようにした。

```ruby
Sentry.capture_exception(e, tags: {source: id, stage: 'fetch'}) if Sentry.initialized?
```

📌 **起票時に「#1467（`before_send` 未設定）との兼ね合いは要検討」とあった件は解消済み。**#1467 は `SentryScrubber` で塞がれており、#1538 で「稼働中に `Config#reload` してもマスクが効く」ことまで確認済み。

## 2. `shrieker_errors` のキーがクラス名依存だった

`"#{self.class}#fetch"` なのでサブクラスごとに増えていた。

```
TomatoShrieker::FeedSource#fetch
TomatoShrieker::GoogleNewsSource#fetch
TomatoShrieker::YouTubeChannelSource#fetch
```

⚠ これが宛先別の分布（`MastodonShrieker` 等）と**同じ Hash に足し込まれる**ので、`/status.json` の `shrieker_errors` が「どの宛先が失敗したか」と「どの処理段階が失敗したか」の混在になっていた。**`source#fetch` に固定**（ソース ID は run_log の行が持っているのでクラス名は冗長）。

🔴 **#1507 で `shrieker_errors` を 503 の本文に出すようにした直後なので、混ざり物は運用者の目に直接入る。**

## 3. ⚠ あわせて: 計上を報告より先に打つ

`logger.error` → `record_failure` の順だった。⚠⚠ **この rescue で `/healthz` を赤にできるのは run_log への計上だけで、Sentry と logger は報告でしかない。**報告を先に打つと、壊れた例外メッセージ（#1469 の族）でそこが落ちたときに**失敗がまったく計上されず run が no-op success に戻る**＝ **#1473 が塞いだ穴が開き直す**。`Source#shriek` には同じ理由の ⚠ コメントが既にある。

## docs

`shrieker_errors` の説明に 2 行足した。

- ⚠ **shrieker クラス名以外の値も入る**（`UnavailableDest` / `source#fetch`）。集計を読むときは区別する
- 🔴 **古い行には `TomatoShrieker::FeedSource#fetch` のような旧キーが残る**

## テスト

3 件追加。**fix を外すと 3 件とも赤くなることを確認済み**（`267 tests, 3 failures`）。

⚠⚠ テスト側で 1 つ踏んだので注記を残してあります。**`Sentry.initialized?` は Sentry 自身の singleton class に生えているので、`define_singleton_method` は本物を上書きする。`remove_method` で戻すと本物ごと消えて、以降のテストが軒並み `NoMethodError` で落ちる**（実際に踏んだ）。元の `Method` を保存して差し戻している。

`267 tests, 969 assertions, 0 failures, 0 errors` / rubocop 94 files clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX8ptAvq1svHGBCFcZFCHM