### PR TITLE
fix: silent を 3 値にして「判定不能」を区別する (#1502)

### DIFF
--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -122,6 +122,7 @@ module TomatoShrieker
       body << "noop_streak: #{SourceRunLog.noop_streak(source.id)}\n"
       # #1505: 静かなだけと分かっているなら `bin/shrieker source ack ID` で緑に戻せる
       body << "silence_baseline: #{source.silence_baseline&.iso8601}\n"
+      body << "silence_baseline_origin: #{source.silence_baseline_origin}\n"
       body << "silence_acknowledged_at: #{SilenceAck.acknowledged_at(source.id)&.iso8601}\n"
       return body
     end
@@ -193,7 +194,13 @@ module TomatoShrieker
         last_delivered_at: source.last_delivered_at&.iso8601,
         last_delivered_at_origin: source.last_delivered_at_origin,
         silence_tolerance_seconds: source.monitor_silence_tolerance_seconds,
+        # 🔴 **3 値 (#1502)。**`null` は「まだ判定できない」＝ run_log 上に配信実績も
+        # 確認記録も無く、観測開始からしきい値も経っていない。⚠ 以前は `false` が
+        # 「健全」と「判定不能」を兼ねていて、外から区別できなかった。
         silent: source.silent?,
+        # なぜその判定なのか。`observation` なら下限（観測開始からの経過）に頼っている
+        silence_baseline: source.silence_baseline&.iso8601,
+        silence_baseline_origin: source.silence_baseline_origin,
         # #1505: 「なぜ緑なのか」を答えられるようにする。確認済みなら silent は
         # false だが、それは健全だからではなく運用者が確認したから
         silence_acknowledged_at: SilenceAck.acknowledged_at(source.id)&.iso8601,

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -4,6 +4,11 @@ module TomatoShrieker
   class Source # rubocop:disable Metrics/ClassLength
     include Package
 
+    # 沈黙の起点の根拠 (#1502)。
+    BASELINE_DELIVERY = 'delivery'.freeze
+    BASELINE_ACKNOWLEDGEMENT = 'acknowledgement'.freeze
+    BASELINE_OBSERVATION = 'observation'.freeze
+
     def initialize(params)
       @params = params
     end
@@ -427,10 +432,36 @@ module TomatoShrieker
     # ソースだけが恒久的に検知対象外になる。
     # ⚠ ローカル変数に at を使わないこと。alias at post_at があるため、
     # 代入より前に現れた at はメソッド呼び出しに解決されて nil になる。
+    # 🔴 **3 値を返す (#1502)。**`true` = 沈黙、`false` = 沈黙していない、
+    # **`nil` = まだ判定できない**。
+    #
+    # ⚠⚠ **`false` が「健全」と「判定不能」を兼ねていた。**#1483 で fallback を
+    # 捨てて `observed_since` 起点にしたので、**run_log 上に配信実績が無いソースは
+    # 「観測開始から tolerance 経過するまで」検知されない**。本番実測では
+    # `precure-toei-event`（180d）の検知が **2027-01-30 まで後ろ倒し**になる。
+    # ⚠ **コードの入れ替えでアラートが消えるのは運用上いちばん紛らわしい**ので、
+    # せめて「黙っているのではなく、まだ判定できない」と言えるようにする。
+    #
+    # ⚠ 判定に使うのは run_log 由来の実配信だけで、last_delivered_at_fallback は見ない (#1483)。
+    # fallback（FeedSource なら entry.published）は配信の成否と無関係に前進するので、
+    # 配信できていなくても silent? が永久に false になる。表示用としては残してある。
+    #
+    # 一度も配信していないソースは、観測を始めてからの経過を無配信期間の下限として使う。
+    # ここを「実績が無いので断定しない」で false にすると、開設以来ずっと壊れている
+    # ソースだけが恒久的に検知対象外になる。
+    # ⚠ ローカル変数に at を使わないこと。alias at post_at があるため、
+    # 代入より前に現れた at はメソッド呼び出しに解決されて nil になる。
     def silent?
+      # しきい値未設定は「この機能を使っていない」＝判定不能ではない。
       return false unless tolerance = monitor_silence_tolerance_seconds
+      # run が 1 件も無いソースは #1560 の領分（`No run recorded yet` で既に 503）。
       return false unless since = silence_baseline
-      return Time.now > (since + tolerance)
+      return true if Time.now > (since + tolerance)
+      # 配信実績も確認記録も無いなら、まだ「沈黙していない」とは言い切れない。
+      # ⚠ **述語が nil を返すのは意図的**（この issue の主題そのもの）。false に
+      # 丸めると「健全」と「判定不能」がまた同じ顔になる。
+      return nil if silence_baseline_origin == BASELINE_OBSERVATION # rubocop:disable Style/ReturnNilInPredicateMethodDefinition
+      return false
     end
 
     # 沈黙を測る起点 (#1505)。配信・確認・観測開始のうち最も新しいもの。
@@ -441,11 +472,26 @@ module TomatoShrieker
     #
     # observed_since は必ず最古の run なので、他の 2 つがあれば max に選ばれない。
     def silence_baseline
-      return [
-        SourceRunLog.last_delivered_at(id),
-        SilenceAck.acknowledged_at(id),
-        SourceRunLog.observed_since(id),
-      ].compact.max
+      return silence_baseline_entry.last
+    end
+
+    # 起点がどれだったか (#1502)。`observation` なら **run_log 上に配信実績も確認記録も
+    # 無い**＝ silent? の判定は観測開始からの経過という下限に頼っている、という意味。
+    # これが出ていないと `silent: false` の理由が外から分からない。
+    def silence_baseline_origin
+      return silence_baseline_entry.first
+    end
+
+    # ⚠ **同時刻なら宣言順で先に書いたものが勝つ。**`max_by` は最初の最大値を返す
+    # ので、初回 run でいきなり配信できたソースは `observation` ではなく `delivery`
+    # になる（`observed_since` と同じ行なので時刻が一致する）。
+    def silence_baseline_entry
+      @silence_baseline_entry ||= {
+        BASELINE_DELIVERY => SourceRunLog.last_delivered_at(id),
+        BASELINE_ACKNOWLEDGEMENT => SilenceAck.acknowledged_at(id),
+        BASELINE_OBSERVATION => SourceRunLog.observed_since(id),
+      }.compact.max_by(&:last) || []
+      return @silence_baseline_entry
     end
 
     def self.all

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -304,6 +304,7 @@ scheduler プロセス生存 + DB 接続 + Rufus ジョブが 1 件以上、す�
 
 ```
 silent? = now > max(last_delivered_at, silence_acknowledged_at, observed_since) + silence_tolerance
+          ただし配信実績も確認記録も無く、まだ超えていなければ nil (= 判定不能・#1502)
 ```
 
 ⚠ **「長期間配信が無い」は一概に失敗と言えない。**上流が静かなだけのこともある（実例: `precure-toei-event` は東映のイベントが実際に開催されていなかった）。とはいえ**何らかのエラーを抱えている疑いがある状態**でもあるので、**いったん赤にして、静かなだけと分かったら運用者が確認して緑に戻す**。
@@ -331,6 +332,20 @@ bin/shrieker source ack ID
 ⚠ **判定に使うのは run_log 由来の実配信だけで、`fallback` は見ない (#1483)。**下記のとおり `fallback` は配信の成否と無関係に前進するため、これを信じると配信できていなくても `silent?` が永久に false になる。
 
 **一度も配信していないソースは、観測を始めてからの経過 (`SourceRunLog.observed_since`) を無配信期間の下限として使う (#1483)。**ここを「配信実績が無いので断定しない」で健全側に倒すと、**開設以来ずっと壊れているソースだけが恒久的に検知対象外になる**という逆立ちした挙動になる。
+
+🔴 **`silent` は 3 値 (#1502)。**`true` = 沈黙、`false` = 沈黙していない、**`null` = まだ判定できない**。
+
+⚠⚠ **`false` が「健全」と「判定不能」を兼ねていた。**上の下限に頼っている以上、**run_log 上に配信実績が無いソースは「観測開始から `silence_tolerance` 経過するまで」検知されない**。2026-09-05 の本番実測では `precure-toei-event`（180d・観測開始 2026-08-03）の検知が **2027-01-30 まで後ろ倒し**になる。⚠ **検知しないこと自体は #1483 の判断どおりで変えない。嘘をつかないようにしただけ。**
+
+**なぜその判定なのかは `silence_baseline_origin` で読む。**
+
+| 値 | 意味 |
+|---|---|
+| `delivery` | run_log 上の実配信が起点。判定は確か |
+| `acknowledgement` | 運用者の確認が起点 (#1505)。緑なのは健全だからではない |
+| `observation` | **観測開始が起点。配信実績も確認記録も無い**＝ `silent` は `null` か、下限だけを根拠にした `true` |
+
+⚠ **初回 run でいきなり配信できたソースは `observed_since` と時刻が一致する**が、`delivery` が勝つ（同着は宣言順）。
 
 #### `/status.json` の中身
 
@@ -360,6 +375,8 @@ bin/shrieker source ack ID
       "noop_streak": 0,
       "silence_tolerance_seconds": null,
       "silent": false,
+      "silence_baseline": "2026-04-14T14:00:01+09:00",
+      "silence_baseline_origin": "delivery",
       "silence_acknowledged_at": null,
       "error_rate_24h": 0.0,
       "duration_ms": {"min": 120, "avg": 380, "max": 1200, "p95": 900},

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -201,6 +201,7 @@ module TomatoShrieker
 
       assert_equal(503, status)
       assert_include(body.first, 'silent: true')
+      assert_include(body.first, 'silence_baseline_origin: delivery')
       assert_include(body.first, 'noop_streak: 1')
     end
 
@@ -433,6 +434,28 @@ module TomatoShrieker
       status, = call("/healthz/source/#{FIXTURE_ID}")
 
       assert_equal(200, status)
+    end
+
+    # 🔴 **`/status.json` で「健全」と「判定不能」を区別できること (#1502)。**
+    # #1483 で observed_since 起点にした結果、run_log 上に配信実績が無いソースは
+    # 「観測開始から tolerance 経過するまで」検知されない。⚠ 検知しないこと自体は
+    # 変えないが、`silent: false` で「健全」と同じ顔をするのはやめる。
+    def test_status_json_silent_is_tri_state
+      record(SILENT_ID, attempted_count: 0, at: Time.now - 60)
+      source = source_status(SILENT_ID)
+
+      assert_true(source.key?('silent'), 'キーごと落としてはいけない')
+      assert_nil(source['silent'], '「健全」と「判定不能」を兼ねている')
+      assert_equal('observation', source['silence_baseline_origin'])
+    end
+
+    # 配信実績があれば判定は確か。⚠ 起点も `delivery` になる
+    def test_status_json_silent_false_when_delivered
+      record(SILENT_ID, attempted_count: 1, delivered_count: 1, at: Time.now - 60)
+      source = source_status(SILENT_ID)
+
+      assert_false(source['silent'])
+      assert_equal('delivery', source['silence_baseline_origin'])
     end
 
     def test_status_json_reports_undelivered

--- a/test/source.rb
+++ b/test/source.rb
@@ -446,11 +446,66 @@ module TomatoShrieker
 
       assert_true(source.silent?)
 
-      # 観測を始めたばかりなら、まだ沈黙とは言えない
+      # 🔴 観測を始めたばかりなら「まだ判定できない」＝ nil (#1502)。
+      # ⚠ ここを false にすると「健全」と区別がつかない。
       source = silent_source({'monitor' => {'silence_tolerance' => '1d'}})
       record_run(at: Time.now - 60)
 
+      assert_nil(source.silent?, '「健全」と「判定不能」を兼ねている')
+    ensure
+      SourceRunLog.where(source_id: SILENT_ID).delete
+    end
+
+    # 🔴 **`silent: false` が「健全」と「判定不能」を兼ねていないこと (#1502)。**
+    # #1483 で fallback を捨てて observed_since 起点にした結果、run_log 上に配信実績が
+    # 無いソースは「観測開始から tolerance 経過するまで」検知されない。本番実測では
+    # `precure-toei-event`（180d）の検知が 2027-01-30 まで後ろ倒しになる。
+    # ⚠ 検知しないこと自体は #1483 の判断どおりで変えない。**嘘をつかないようにする。**
+    def test_silent_states
+      # 配信実績があってしきい値内 ＝ 健全
+      source = silent_source({'monitor' => {'silence_tolerance' => '1d'}})
+      record_run(at: Time.now - 60, delivered_count: 1)
+
       assert_false(source.silent?)
+      assert_equal('delivery', source.silence_baseline_origin)
+
+      # 配信実績が無く観測も浅い ＝ 判定不能
+      source = silent_source({'monitor' => {'silence_tolerance' => '1d'}})
+      record_run(at: Time.now - 60)
+
+      assert_nil(source.silent?)
+      assert_equal('observation', source.silence_baseline_origin)
+
+      # しきい値未設定は「この機能を使っていない」＝判定不能ではない
+      source = silent_source
+      record_run(at: Time.now - 60)
+
+      assert_false(source.silent?)
+    ensure
+      SourceRunLog.where(source_id: SILENT_ID).delete
+    end
+
+    # ⚠ 運用者が確認したら判定不能ではなくなる。起点も `acknowledgement` に変わるので、
+    # 「なぜ緑なのか」が外から読める (#1505)。
+    def test_silence_baseline_origin_after_acknowledge
+      source = silent_source({'monitor' => {'silence_tolerance' => '1d'}})
+      record_run(at: Time.now - 60)
+      SilenceAck.acknowledge(SILENT_ID)
+
+      assert_false(source.silent?)
+      assert_equal('acknowledgement', source.silence_baseline_origin)
+    ensure
+      SourceRunLog.where(source_id: SILENT_ID).delete
+      SilenceAck.where(source_id: SILENT_ID).delete
+    end
+
+    # ⚠ 初回 run でいきなり配信できたソースは、observed_since と同じ行なので時刻が
+    # 一致する。`observation` ではなく `delivery` になること。
+    def test_silence_baseline_origin_prefers_delivery_on_tie
+      source = silent_source({'monitor' => {'silence_tolerance' => '1d'}})
+      record_run(at: Time.now - 60, delivered_count: 1)
+
+      assert_equal('delivery', source.silence_baseline_origin)
     ensure
       SourceRunLog.where(source_id: SILENT_ID).delete
     end
@@ -504,9 +559,10 @@ module TomatoShrieker
       SourceRunLog.where(source_id: SILENT_ID).delete
     end
 
-    def test_silent_boolean
+    # ⚠ #1502 で 3 値になった。`nil`（判定不能）も正当な返り値。
+    def test_silent_tri_state
       Source.all do |source|
-        assert_boolean(source.silent?)
+        assert_include([true, false, nil], source.silent?)
       end
     end
 


### PR DESCRIPTION
Closes #1502

**issue の案 3（観測が浅いソースを可視化する）**で畳みます。⚠ **検知しないこと自体は #1483 の判断どおりで変えません。嘘をつかないようにしただけです。**

## 何が問題だったか

#1483 で fallback を捨てて `observed_since` 起点にした結果、**run_log 上に配信実績が無いソースは「観測開始から `silence_tolerance` 経過するまで」検知されない**。その間 `silent: false` が **「健全」と「判定不能」を兼ねていた**。

### 本番実測（2026-09-05・oscura）

起票時の 6 件は 2 件まで減っていました（残りはその後配信できたため）。

| ソース | tolerance | observed_since | 検知が効き始める |
|---|---|---|---|
| `precure-toei-event` | 180d | 2026-08-03 | **2027-01-30** |
| `precure-toei-news` | 90d | 2026-08-03 | 2026-11-01 |

`silence_tolerance` を設定した 30 件のうち、この 2 件だけが `last_delivered_at_origin != run_log`。

## 直し方

**`Source#silent?` を 3 値にしました。**`true` = 沈黙 / `false` = 沈黙していない / **`null` = まだ判定できない**。

```
silent? = now > max(last_delivered_at, silence_acknowledged_at, observed_since) + silence_tolerance
          ただし配信実績も確認記録も無く、まだ超えていなければ nil
```

**「なぜその判定なのか」は `silence_baseline_origin` で読めるようにしました。**

| 値 | 意味 |
|---|---|
| `delivery` | run_log 上の実配信が起点。判定は確か |
| `acknowledgement` | 運用者の確認が起点 (#1505)。緑なのは健全だからではない |
| `observation` | **観測開始が起点。配信実績も確認記録も無い** |

`/status.json` に `silence_baseline` / `silence_baseline_origin` を追加し、503 の本文にも起点を出します。

## ⚠ 判断したこと

- **`silence_tolerance` 未設定は `false` のまま。**「この機能を使っていない」であって判定不能ではない（`silence_tolerance_seconds: null` で既に読める）
- **run が 1 件も無いソースも `false` のまま。**そちらは #1560 の領分で、`No run recorded yet` で既に 503 になる
- **同着は `delivery` が勝つ。**初回 run でいきなり配信できたソースは `observed_since` と時刻が一致するため
- ⚠ **述語が nil を返すのは意図的**なので、その 1 行だけ `Style/ReturnNilInPredicateMethodDefinition` を無効化しました。false に丸めると元の問題に戻ります
- **`/healthz` と Kuma の挙動は変わりません。**`nil` は falsy なので 503 の判定は同じ

## テスト

5 件追加・1 件を `assert_false` → `assert_nil` に変更。**3 値化を外すと 3 件が赤くなることを確認済み。**

`272 tests, 983 assertions, 0 failures, 0 errors` / rubocop 94 files clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX8ptAvq1svHGBCFcZFCHM