### PR TITLE
fix: LineShrieker の初期化失敗の真因を healthz まで届ける (#1487)

### DIFF
--- a/app/lib/tomato_shrieker/shrieker/line_shrieker.rb
+++ b/app/lib/tomato_shrieker/shrieker/line_shrieker.rb
@@ -5,9 +5,18 @@ module TomatoShrieker
     def initialize(params = {})
       # 親の初期化は config が無い環境でも落とさない。ただし黙って捨てると
       # 後段の say 失敗の原因が追えなくなるので記録は残す (#1473)。
+      #
+      # ⚠ **ここで落とさないのは意図的。**組み立てに失敗すると `shriekers` から
+      # この宛先が消え、「設定はあるのに宛先ゼロ」になって #1504 の計上が崩れる。
       begin
         super
       rescue => e
+        # 🔴 **失敗を持ち越す (#1487)。**握ったまま続行すると `@http.base_uri` が
+        # 未設定のまま残り、後段の `say` が
+        # `NoMethodError: undefined method 'prefix' for nil` で落ちる。
+        # ⚠⚠ **run_log と `/healthz` に出るのは真因の `Ginseng::ConfigError` ではなく
+        # 症状の `NoMethodError`** になり、運用者は原因にたどり着けない。
+        @init_error = e
         logger.error(shrieker: self.class.to_s, error: e, message: 'initialization failed')
       end
       @id = params[:id]
@@ -15,6 +24,11 @@ module TomatoShrieker
     end
 
     def exec(body)
+      # ⚠ **投げ直すのは exec の冒頭。**`Source#shriek` の rescue が `source: id` 付きで
+      # 記録するので、真因がそのまま run_log → `/healthz` まで届く。
+      # ⚠ 初期化時のログにソース ID は入らない（LineShrieker は自分の source を
+      # 知らない）。**本番の LINE ソースは 2 件あるので、ログだけでは判別できない。**
+      raise @init_error if @init_error
       body = body.clone
       body[:template][:tag] = false
       return say(body[:template].to_s.strip)

--- a/test/line_shrieker.rb
+++ b/test/line_shrieker.rb
@@ -53,12 +53,18 @@ module TomatoShrieker
     # `Ginseng::LineService#initialize` が落ちるのは `/line/urls/api` の欠落時だけ。
     #
     # ⚠ **`raw` の鍵は設定ファイルの basename**（`local` / `application` / `lib` /
-    # hostname）で、優先順は `Config#basenames` の順。低い側へ書いても高い側の値に
-    # 上書きされるので、**実在するうちいちばん強い basename** を差し替える。
+    # hostname）で、優先順は `Config#basenames` の順。
+    #
+    # 🔴🔴 **「いちばん強い basename から消す」では効かない。**`Config#load` は
+    # basename ごとに `update(key_flatten)` するので、**強い側でキーを消しても弱い側の
+    # 値がそのまま残る**。⚠ 実際に踏んだ: 手元には `local.yaml` が無いので
+    # `application` を削って通ったが、**CI は `local_sample.yaml` を `local.yaml` へ
+    # コピーする**ため `local` が選ばれ、`application` の値が生き残って落ちなかった。
+    # **nil で明示的に上書きする**（`Config#[]` は nil を「無い」として扱う）。
     def with_broken_line_config
       key = config.basenames.find {|v| config.raw.key?(v)}
       original = config.raw[key]['line']
-      config.raw[key]['line'] = (original || {}).deep_dup.tap {|v| v.delete('urls')}
+      config.raw[key]['line'] = {'urls' => {'api' => nil}}
       config.reload
       yield
     ensure

--- a/test/line_shrieker.rb
+++ b/test/line_shrieker.rb
@@ -19,4 +19,51 @@ module TomatoShrieker
       end
     end
   end
+
+  # ⚠ **`LineShriekerTest` とは別クラスにする。**あちらは `disable?` で
+  # 「test 用の LINE ソースが無ければケースごと省略」する（#1520）ので、
+  # **設定の壊れ方を見るテストが本番設定の有無に左右されてしまう。**
+  class LineShriekerConfigTest < TestCase
+    # 🔴 **初期化に失敗しても Shrieker は作れること (#1473)。**
+    # ⚠ ここで落とすと `shriekers` からこの宛先が消え、「設定はあるのに宛先ゼロ」に
+    # なって #1504 の計上が崩れる。
+    def test_new_survives_broken_config
+      with_broken_line_config do
+        assert_nothing_raised {LineShrieker.new({id: 'u', token: 't'})}
+      end
+    end
+
+    # 🔴 **exec には真因がそのまま出ること (#1487)。**
+    #
+    # ⚠⚠ 以前は初期化失敗を握って続行していたので `@http.base_uri` が未設定のまま
+    # 残り、`say` が `NoMethodError: undefined method 'prefix' for nil` で落ちていた。
+    # **run_log と `/healthz` に出るのは真因の `Ginseng::ConfigError` ではなく症状の
+    # `NoMethodError`** で、運用者は原因にたどり着けない。
+    def test_exec_raises_initialization_error
+      with_broken_line_config do
+        shrieker = LineShrieker.new({id: 'u', token: 't'})
+        error = assert_raise_kind_of(StandardError) {shrieker.exec({template: 'x'})}
+
+        assert_kind_of(Ginseng::ConfigError, error, '症状ではなく真因を出すこと')
+      end
+    end
+
+    private
+
+    # `Ginseng::LineService#initialize` が落ちるのは `/line/urls/api` の欠落時だけ。
+    #
+    # ⚠ **`raw` の鍵は設定ファイルの basename**（`local` / `application` / `lib` /
+    # hostname）で、優先順は `Config#basenames` の順。低い側へ書いても高い側の値に
+    # 上書きされるので、**実在するうちいちばん強い basename** を差し替える。
+    def with_broken_line_config
+      key = config.basenames.find {|v| config.raw.key?(v)}
+      original = config.raw[key]['line']
+      config.raw[key]['line'] = (original || {}).deep_dup.tap {|v| v.delete('urls')}
+      config.reload
+      yield
+    ensure
+      config.raw[key]['line'] = original
+      config.reload
+    end
+  end
 end


### PR DESCRIPTION
Closes #1487

## 何が起きていたか

`LineShrieker#initialize` は親の初期化に失敗しても続行するので `@http.base_uri` が未設定のまま残り、後段の `say` が `NoMethodError: undefined method 'prefix' for nil` で落ちる。

`Source#shriek` の rescue に拾われるので**検知はされる**。⚠⚠ **ただし `/healthz/source/:id` の `error:` と `/status.json` の `last_error` に出るのは、真因の `Ginseng::ConfigError` ではなく症状の `NoMethodError`。**運用者は原因にたどり着けない。

## 直し方（issue の案どおり）

初期化失敗を `@init_error` に持ち、`exec` の冒頭で投げ直す。

- **真因がそのまま `record_error` → run_log → `/healthz` まで届く**
- **`Source#shriek` の rescue が `source: id` 付きで記録するので、ログ側でソースを特定する必要もなくなる**（初期化時のログにソース ID は入らず、⚠ **本番の LINE ソースは 2 件ある**ので従来はログだけでは判別できなかった）

⚠ **初期化そのもので落とさないのは意図的。**組み立てに失敗すると `shriekers` からこの宛先が消え、**「設定はあるのに宛先ゼロ」**になって #1504 の計上が崩れます。

## テスト

⚠⚠ **`LineShriekerTest` とは別クラスにしました。**あちらは `disable?` で「test 用の LINE ソースが無ければケースごと省略」する（#1520）ので、**設定の壊れ方を見るテストが本番設定の有無に左右されてしまいます**。実際、最初は同じクラスに置いて omission になり、走っていませんでした。

2 件追加。**fix を外すと `test_exec_raises_initialization_error` が赤くなることを確認済み。**

`280 tests, 997 assertions, 0 failures, 0 errors` / rubocop 94 files clean。

📌 **走行中に `test_prune_keeps_first_run_row` が 1 回落ちました**が、これは既知の非決定要因（#1553・`Time.now` を 2 回呼んで秒境界で落ちる）で、再実行で緑。本 PR とは無関係です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YX8ptAvq1svHGBCFcZFCHM