### PR TITLE
deps: ginseng-* 4 本を版で固定する (pooza/ginseng-style#103)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 ruby '>= 3.4', '< 5.0'
 gem 'feedjira', '~>3.0'
-gem 'ginseng-core', github: 'pooza/ginseng-core', branch: 'main', require: 'ginseng'
-gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', branch: 'main',
+gem 'ginseng-core', github: 'pooza/ginseng-core', tag: 'v1.23.5', require: 'ginseng'
+gem 'ginseng-fediverse', github: 'pooza/ginseng-fediverse', tag: 'v1.8.31',
   require: 'ginseng/fediverse'
-gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', branch: 'main', require: 'ginseng/piefed'
-gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', branch: 'main', require: 'ginseng/you_tube'
+gem 'ginseng-piefed', github: 'pooza/ginseng-piefed', tag: 'v0.1.1', require: 'ginseng/piefed'
+gem 'ginseng-youtube', github: 'pooza/ginseng-youtube', tag: 'v3.0.1', require: 'ginseng/you_tube'
 gem 'icalendar'
 gem 'icalendar-rrule', github: 'pooza/icalendar-rrule',
   ref: '396a2c3e6b5cf394c2416f39c05e948cccd4ea52'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/pooza/ginseng-core.git
   revision: d53a18b5c74d13af6b78b6a7ae6e0c6a7a0caa88
-  branch: main
+  tag: v1.23.5
   specs:
     ginseng-core (1.23.5)
       activesupport (>= 8.1.2.1)
@@ -34,15 +34,15 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-fediverse.git
-  revision: 8d6d1fa6f9e49f71347cd3b47eea794f12ae8f45
-  branch: main
+  revision: f6e160a2794db2573b9210eea23ab7593dcc5123
+  tag: v1.8.31
   specs:
     ginseng-fediverse (1.8.31)
 
 GIT
   remote: https://github.com/pooza/ginseng-piefed.git
-  revision: afddcdace7ae524cfba4967e5f7de97637bbea32
-  branch: main
+  revision: ec2bf39fd0c706c33a9d159fb13fd8006b001927
+  tag: v0.1.1
   specs:
     ginseng-piefed (0.1.1)
 
@@ -59,8 +59,8 @@ GIT
 
 GIT
   remote: https://github.com/pooza/ginseng-youtube.git
-  revision: 71415a45d291f7a823e1b51c397e4651d9625237
-  branch: main
+  revision: 74b9f344df15ab8a2f6f09808781f97e6ad872a5
+  tag: v3.0.1
   specs:
     ginseng-youtube (3.0.1)
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -818,21 +818,34 @@ Nostr 対応は外部ユーザーのリクエストで実装された機能。�
 
 🔴 **作業ツリーの `Gemfile.lock` を読んではいけない。**チェックアウトが古い feature ブランチに乗っていると、**そのブランチのピンを現状と誤読する**。2026-08-25 の sync では、サテライト 3 本が `chore/*-ginseng-style` に乗っていたせいで **ahead=103（実際は 21）** と出て、追随済みのものを未追随と誤判定しかけた。**必ず追跡ブランチから取り出す**（上記のとおり tomato は `origin/develop`、サテライトは `origin/HEAD`）。
 
+🔴🔴 **`ginseng-*` は版（タグ）で固定してある (pooza/ginseng-style#103)。**⚠⚠ **したがって `bundle update <gem>` では上がらない。**Bundler は `Gemfile` の要求を第一に見るので、`tag:` が古いままだといくら `bundle update` しても `Gemfile.lock` は動かない。⚠ **`.github/dependabot.yml` は `open-pull-requests-limit: 0`** なので通常の version-update PR も来ない。**追随は `Gemfile` の `tag:` を書き換える作業**で、`bundle update` はそのあとの lock 更新にすぎない。
+
+🔴 **比べる相手は `main` ではなく「最新のタグ」。**`main` と比べると、**上流がまだ版を切っていないぶん**まで「遅れ」に見える（実例: 2026-09-12 の `ginseng-style` は `v1.1.12` 固定で `main` から 4 コミット先だが、**新しいタグは無い** ＝ 追随できない・待ち）。
+
 ```sh
 for d in tomato-shrieker loquat shooby-do-bop dqdai-anniv; do
   # ⚠ tomato 自身だけ develop。origin/HEAD は main ＝ リリース済みの版 (#1550)
   ref=origin/HEAD; [ "$d" = tomato-shrieker ] && ref=origin/develop
   git -C ~/repos/$d fetch -q origin
-  git -C ~/repos/$d show $ref:Gemfile.lock |
-  awk '/github\.com\/pooza\/ginseng-/{g=$2; sub(/.*\//,"",g); sub(/\.git/,"",g); f=1} f&&/revision:/{print g, $2; f=0}' |
-  while read -r gem rev; do
-    ahead=$(gh api repos/pooza/$gem/compare/$rev...main --jq .ahead_by 2>/dev/null)
-    printf '%-16s %-18s %s\n' "$d" "$gem" "${ahead:-?}"
+  # Gemfile の tag: が正本。⚠ Gemfile.lock の revision: は結果なので読まない
+  # ⚠ 1 つの gem 宣言が 2 行に折られていることがあるので、継続行を畳んでから読む
+  git -C ~/repos/$d show $ref:Gemfile |
+  sed -e :a -e '/,$/N; s/\n[[:space:]]*/ /; ta' | tr -d "'" |
+  awk '/pooza\/ginseng-/{g=t="";for(i=1;i<=NF;i++){if($i=="github:")g=$(i+1);if($i=="tag:")t=$(i+1)}
+    sub(/.*\//,"",g); sub(/,$/,"",g); sub(/,$/,"",t); if(t!="")print g, t}' |
+  while read -r gem tag; do
+    latest=$(gh api repos/pooza/$gem/tags --jq '.[0].name' 2>/dev/null)
+    mark=$([ "$tag" = "$latest" ] && echo '' || echo '  <-- 追随する')
+    printf '%-16s %-18s %-10s latest=%-10s%s\n' "$d" "$gem" "$tag" "${latest:-?}" "$mark"
   done
 done
 ```
 
-遅れがあれば `bundle update <gem>` で追随する。⚠ **ルーチンの `Gemfile.lock` 最新化は PR 不要・`develop` 直コミットでよい**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。ただし**溜めてから一気に追随するときは単独 PR にして、本番で挙動を観察する**。
+追随は **`Gemfile` の `tag:` を最新タグへ書き換えてから `bundle update <gem>`**。⚠ **両方やる。**`tag:` だけだと lock が古いまま、`bundle update` だけだと何も起きない。
+
+⚠ **ルーチンの追随は PR 不要・`develop` 直コミットでよい**（[ginseng-style の workflow.md](https://github.com/pooza/ginseng-style/blob/main/docs/workflow.md)）。ただし**溜めてから一気に追随するときは単独 PR にして、本番で挙動を観察する**。
+
+📌 **「main より先だが新しいタグが無い」は待ち。**上流へ版を切るよう促すのは可だが、`ref:`/`branch:` へ戻して固定を外してはいけない（固定の意味が消える）。
 
 ⚠ **追随で「必須の設定キー」が増えていることがある。**実例: ginseng-core 1.19.0 の `HTTP#initialize` は `/http/timeout/seconds` を読み、`/http/retry/max_seconds` と違って**既定へ倒れない**。無いと HTTP を作った時点で `ConfigError` になる（本体・サテライトとも `30` を設定済み）。**必ずローカルで `rake test` を通してから push する。**
 


### PR DESCRIPTION
`ginseng-*` の参照を **版（タグ）固定へ**移します。pooza/ginseng-style#103 のロールアウトです。

## なぜ

⚠⚠ **未固定だと、向こうの `main` にマージされた瞬間が露出**になります。いま壊れないのは `Gemfile.lock` が守っているからで、破綻は 🔴 **次の `bundle update`（＝無関係な PR の中）**で出ます。固定すると受け皿が **版を上げる PR の CI** に変わります。

⚠ おまけに dependabot の PR タイトルが SHA から **`bump ginseng-core from v1.23.5 to ...`** になり、版として読めるようになります。

## ⚠ これは「更新」ではなく「記録」です

| gem | 変更前 | 変更後 |
| --- | --- | --- |
| `ginseng-core` | `revision: d53a18b5` / `branch: main` | ✅ **同一** / `tag: v1.23.5` |
| `ginseng-fediverse` | `revision: 8d6d1fa6` / `branch: main` | `revision: f6e160a2` / `tag: v1.8.31` |
| `ginseng-piefed` | `revision: afddcdac` / `branch: main` | `revision: ec2bf39f` / `tag: v0.1.1` |
| `ginseng-youtube` | `revision: 71415a45` / `branch: main` | `revision: 74b9f344` / `tag: v3.0.1` |

⚠⚠ **revision が動く場合も配布物は完全に同一**です。タグと lock の revision の差分は `.github/workflows/*` と**向こう自身の `Gemfile`**（`ginseng-style` の版上げ）だけで、`release.yml` の `paths` に入るファイルの差分はゼロであることを実測しました。

## 検証

- 版の行に差分なし（1.23.5 / 1.8.31 / 0.1.1 / 3.0.1 のまま）
- `bundle exec rubocop` → ✅ **94 files / no offenses**
- ⚠ `bundle exec rake test` → **285 tests / 176 errors（64.2066% passed）**。🔴 **この PR のせいではありません** — 手元では `main` でも**同じ 64.2066%**（外部依存のある環境差）。判定は CI にお願いします
- ⚠ `ginseng-fediverse` の行は `tag:` を足すと 100 桁を超えるので `require:` の前で折りました（pooza/ginseng-style#80 で `Gemfile` も lint 対象）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CuNhF8dFKWunP99LifBqbV
---

## 🔴 追記（2026-09-12 の sync）: Codex の P1 に対応した

`f9cb10d` で **`docs/CLAUDE.md` のピン棚卸し手順**を直しました。指摘は仮定ではなく**現に効いていました**。

```
tomato-shrieker / loquat / shooby-do-bop / dqdai-anniv   ginseng-core   ahead=5
```

⚠⚠ **その 5 件は `v1.23.7` で丸ごとタグが切られている**（`v1.23.7...main` は ahead=0）ので、**この PR をそのまま入れると「`v1.23.5` 固定のまま `bundle update` では上がらない」状態になります。**

- 追随は **`Gemfile` の `tag:` を書き換えてから `bundle update <gem>`**（⚠ 両方やる）
- 🔴 **比べる相手を `main` から「最新のタグ」へ。**`main` と比べると上流がまだ版を切っていないぶんまで遅れに見える（`ginseng-style` は `v1.1.12` 固定で `main` から 4 コミット先だが**新しいタグが無い** ＝ 待ち）
- 読む先を `Gemfile.lock` の `revision:` から `Gemfile` の `tag:` へ（継続行を畳んでから読む）

## ⚠ 前回の「検証」にあった 176 errors について

本文上の `rake test` が **285 tests / 176 errors** になっていたのは**この PR のせいではなく、LAN 外からの実行だったため**です。2026-09-12 に LAN 内で回した実測は **285 tests / 4 errors**（4 件はすべて YouTube フィードの間欠 404 ＝ #1579）で、`main` でも同じです。**CI は緑**（`test pass 1m32s`）。

## 📌 次の 1 手

**この PR は「記録」のままにして、`ginseng-core` → `v1.23.7` の追随は別 PR にします。**受け皿が「版を上げる PR の CI」に変わるのがこの固定の眼目なので、それを最初の 1 件で実演します。⚠ **サテライト 3 本（loquat#30 / shooby-do-bop#365 / dqdai-anniv#39）も同じ形で同時に動かすこと。**