### PR TITLE
4.9.0

### DIFF
--- a/app/lib/tomato_shrieker/model/source_run_log.rb
+++ b/app/lib/tomato_shrieker/model/source_run_log.rb
@@ -297,8 +297,12 @@ module TomatoShrieker
 
     # error_streak_threshold が sample_size より大きいと、読む行数が足りず
     # しきい値に到達し得ない＝どれだけ連続で失敗しても健全のままになる。
-    def self.streak_window
-      return [sample_size, Config.instance['/monitor/error_streak_threshold']].max
+    #
+    # ⚠ **しきい値はソース単位で上書きできる (#1558)。**呼び出し側が解決した値を
+    # 渡す。⚠ 省略時はグローバル値で、ソースを持たない呼び出し（prune 等）向け。
+    def self.streak_window(threshold = nil)
+      threshold ||= Config.instance['/monitor/error_streak_threshold']
+      return [sample_size, threshold].max
     end
   end
 end

--- a/app/lib/tomato_shrieker/model/source_run_log.rb
+++ b/app/lib/tomato_shrieker/model/source_run_log.rb
@@ -207,13 +207,26 @@ module TomatoShrieker
     # 直近 N 件から求まる指標をまとめて返す。
     # /status.json は全ソース分を 1 リクエストで返すので、
     # 指標ごとに recent_for を呼ぶとソース数 × 指標数のクエリになる。ここで 1 回に畳む。
+    # ⚠⚠ **streak だけ広い窓で読み、他の指標は sample_size で切る (#1558)。**
+    # しきい値をソース単位で `sample_size` より大きくすると窓が広がるが、
+    # **`noop_streak` / `duration_ms` / `shrieker_errors` まで一緒に広げてはいけない。**
+    # `/monitor/sample_size` の「統計の算出に使う直近 run 件数」という定義に反し、
+    # 🔴 **503 本文（`sample_size` 固定）と `/status.json` が同名フィールドで違う数字**
+    # を出す。4.8.0 で `last_attempted_count` で潰したのと同じ型の不具合。
+    # ⚠ 追加のクエリは打たない（`logs` を切るだけ）。#1472 の約 900ms を増やさない。
     def self.summary_for(source_id, limit: streak_window)
-      logs = recent_for(source_id, limit)
+      return summary_of(recent_for(source_id, limit))
+    end
+
+    # 取得済みの logs から出す版。⚠ **呼び出し側が logs を別の用途にも使うとき**
+    # （`entry_level_error?` の判定等）に、同じ行を 2 回引かないため (#1558)。
+    def self.summary_of(logs)
+      sample = logs.first(sample_size)
       return {
         error_streak: error_streak_of(logs),
-        noop_streak: noop_streak_of(logs),
-        duration_ms: duration_stats_of(logs),
-        shrieker_errors: shrieker_error_distribution_of(logs),
+        noop_streak: noop_streak_of(sample),
+        duration_ms: duration_stats_of(sample),
+        shrieker_errors: shrieker_error_distribution_of(sample),
       }
     end
 
@@ -225,6 +238,25 @@ module TomatoShrieker
     # 「単発で倒さない」は error_streak_threshold で調整する。
     def self.error_streak(source_id, limit: streak_window)
       return error_streak_of(recent_for(source_id, limit))
+    end
+
+    # 🔴🔴 **しきい値の緩和を効かせてよい失敗か (#1558)。**
+    #
+    # ⚠⚠ **エントリを読んだ後に落ちた失敗は、1 回で赤にしないとエントリを失う。**
+    # `Entry.insert` は配信より先に走るので、`create_record` / `create_template` /
+    # `enclosures` / `Entry#shriek` 以降で落ちた run のエントリは**unique 制約で
+    # 二度と取得されず恒久的に失われる**。しかもその失敗は `record_failure` 経由で
+    # `attempted_count` に載らないため、**`undelivered?` も `stale` も `silent` も
+    # 立たない**＝ `error_streak` が唯一のゲート（#1473 / DeliveryStats のコメント）。
+    #
+    # 📌 **run_log 上で 2 つの失敗族は既に区別できている。**フィード取得そのものの
+    # 失敗（#1558 の動機である YouTube の 404）は `entries` の評価中に抜けるので
+    # `shrieker_errors` が空。エントリ単位の失敗は `source#fetch` が載る。
+    #
+    # ⚠ **仕様は 1 行で言える: 「しきい値を緩められるのは、エントリを 1 件も
+    # 読めていない失敗だけ」。**取得が不安定な相手は許容するが、取りこぼしは許容しない。
+    def self.entry_level_error?(logs)
+      return logs.take_while(&:error?).any? {|log| log.shrieker_error_counts.present?}
     end
 
     def self.error_streak_of(logs)

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -69,8 +69,11 @@ module TomatoShrieker
       # 連続エラーで判定する (#1457)。何回で倒すかは error_streak_threshold で調整する。
       # ⚠ **しきい値はソース単位で上書きできる (#1558)。**読む行数もそれに従わせないと、
       # しきい値だけ大きくしても窓が足りず、到達し得ないまま健全扱いになる。
-      threshold = source.monitor_error_streak_threshold
-      streak = SourceRunLog.error_streak(source.id, limit: SourceRunLog.streak_window(threshold))
+      logs = SourceRunLog.recent_for(
+        source.id, SourceRunLog.streak_window(source.monitor_error_streak_threshold)
+      )
+      streak = SourceRunLog.error_streak_of(logs)
+      threshold = effective_error_streak_threshold(source, logs)
       return {
         next_run:,
         stale: Time.now > next_run + source.monitor_grace_seconds,
@@ -84,6 +87,20 @@ module TomatoShrieker
         # 判定は Source 側に寄せてある。
         undelivered: (source.undelivered_log if source.undelivered?),
       }
+    end
+
+    # 🔴🔴 **緩和を効かせてよい失敗かを見てから、しきい値を決める (#1558)。**
+    #
+    # ⚠⚠ **エントリを読んだ後に落ちた失敗は 1 回で赤にする。**緩めるとそのぶんの
+    # エントリが**恒久的に失われる**（`Entry.insert` は配信より先・unique 制約で
+    # 再取得されない）のに、`undelivered` / `stale` / `silent` のどれも立たないので
+    # **`error_streak` が唯一のゲート**になっている（#1473）。
+    #
+    # 📌 緩められるのは「エントリを 1 件も読めていない失敗」＝フィード取得そのものの
+    # 失敗だけ。#1558 の動機である YouTube の 404 はこちら。
+    def effective_error_streak_threshold(source, logs)
+      return 1 if SourceRunLog.entry_level_error?(logs)
+      return source.monitor_error_streak_threshold
     end
 
     def unhealthy?(checks)
@@ -206,7 +223,18 @@ module TomatoShrieker
     # #1433 (統計) と #1470 (サイレント不発) の指標。
     def delivery_status(source, latest)
       attempted = SourceRunLog.last_attempted(source.id)
-      return SourceRunLog.summary_for(source.id).merge(
+      # 🔴 **窓もしきい値も /healthz/source/:id と完全に同じものを使う（Codex P2・#1558）。**
+      # 既定の窓はグローバルのしきい値しか見ないので、ソース側で sample_size (50) を
+      # 超える値に上書きすると **503 にしている当人が `error_streak: 50 / 100` という
+      # 自己矛盾した数字を出す**。⚠⚠ **しきい値も「宣言値」ではなく実効値を出す。**
+      # `effective_error_streak_threshold` が 1 に倒している場合、宣言値を出すと
+      # `/healthz` が `1 / 1` で 503 なのに `/status.json` は `4` と言う。
+      # ⚠ **2 つのエンドポイントが同名フィールドで違う数字を出す**のは 4.8.0 の
+      # レビューで `last_attempted_count` で潰した型の不具合なので、繰り返さない。
+      logs = SourceRunLog.recent_for(
+        source.id, SourceRunLog.streak_window(source.monitor_error_streak_threshold)
+      )
+      return SourceRunLog.summary_of(logs).merge(
         dest_count: source.dest_count,
         # #1504: 直近の配信試行の内訳。undelivered が true なら未解決の取りこぼしがある
         last_attempted_at: attempted&.executed_at&.iso8601,
@@ -235,7 +263,7 @@ module TomatoShrieker
         silence_acknowledged_at: SilenceAck.acknowledged_at(source.id)&.iso8601,
         error_rate_24h: SourceRunLog.error_rate(source.id),
         # #1558: 「なぜこのソースはまだ緑なのか」を外から説明できるようにする
-        error_streak_threshold: source.monitor_error_streak_threshold,
+        error_streak_threshold: effective_error_streak_threshold(source, logs),
       )
     end
 

--- a/app/lib/tomato_shrieker/monitor/monitor_app.rb
+++ b/app/lib/tomato_shrieker/monitor/monitor_app.rb
@@ -67,12 +67,16 @@ module TomatoShrieker
     def source_checks(source, latest)
       next_run = source.next_run_at(latest.executed_at)
       # 連続エラーで判定する (#1457)。何回で倒すかは error_streak_threshold で調整する。
-      streak = SourceRunLog.error_streak(source.id)
+      # ⚠ **しきい値はソース単位で上書きできる (#1558)。**読む行数もそれに従わせないと、
+      # しきい値だけ大きくしても窓が足りず、到達し得ないまま健全扱いになる。
+      threshold = source.monitor_error_streak_threshold
+      streak = SourceRunLog.error_streak(source.id, limit: SourceRunLog.streak_window(threshold))
       return {
         next_run:,
         stale: Time.now > next_run + source.monitor_grace_seconds,
         streak:,
-        errored: streak >= error_streak_threshold,
+        threshold:,
+        errored: streak >= threshold,
         silent: source.silent?,
         # 試みたのに届かなかった宛先がある (#1504)。取りこぼしは再送されないので、
         # 次に全宛先へ届くか、運用者が確認するまで解除しない (#1506)。
@@ -93,7 +97,7 @@ module TomatoShrieker
       body << "next_run_at: #{checks[:next_run].iso8601}\n"
       body << "grace_seconds: #{source.monitor_grace_seconds}\n"
       body << "stale: #{checks[:stale]}\n"
-      body << "error_streak: #{checks[:streak]}\n"
+      body << "error_streak: #{checks[:streak]} / #{checks[:threshold]}\n"
       body << failure_body(latest)
       body << undelivered_body(checks[:undelivered], latest) if checks[:undelivered]
       body << silent_body(source) if checks[:silent]
@@ -230,11 +234,9 @@ module TomatoShrieker
         # false だが、それは健全だからではなく運用者が確認したから
         silence_acknowledged_at: SilenceAck.acknowledged_at(source.id)&.iso8601,
         error_rate_24h: SourceRunLog.error_rate(source.id),
+        # #1558: 「なぜこのソースはまだ緑なのか」を外から説明できるようにする
+        error_streak_threshold: source.monitor_error_streak_threshold,
       )
-    end
-
-    def error_streak_threshold
-      return Config.instance['/monitor/error_streak_threshold']
     end
 
     def scheduler_alive?

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -400,13 +400,14 @@ module TomatoShrieker
     # 状態になるので、道具側に置く。
     def monitor_error_streak_threshold
       value = self['/monitor/error_streak_threshold']
-      return default_error_streak_threshold unless value.is_a?(Numeric)
-      return value.to_i if value.to_i.positive?
+      return default_error_streak_threshold if value.nil?
+      # ⚠ **回数に単位は無いので整数だけ受ける。**`silence_tolerance` は Rufus の
+      # duration を受けるが、ここで文字列を許す理由が無い。⚠ `'4'` を黙って
+      # 既定へ倒すと「4 にしたのに 1 回で赤い」を延々踏むので warn を出す。
+      return warn_threshold(value, 'not an integer') unless value.is_a?(Integer)
+      return value if value.positive?
       # 0 や負値は「1 回も失敗していなくても赤」になるだけなので、既定へ倒す
-      logger.warn(
-        source: id, key: 'monitor/error_streak_threshold', value:, message: 'not positive',
-      )
-      return default_error_streak_threshold
+      return warn_threshold(value, 'not positive')
     end
 
     # 無配信をどこまで許容するか (#1470)。
@@ -428,6 +429,13 @@ module TomatoShrieker
 
     def default_error_streak_threshold
       return Config.instance['/monitor/error_streak_threshold']
+    end
+
+    # ⚠ スキーマ (`type: integer` / `minimum: 1`) は load 時に当たらない
+    # （`source edit` / `source validate` だけ）ので、実行時に不正値が来うる。
+    def warn_threshold(value, message)
+      logger.warn(source: id, key: 'monitor/error_streak_threshold', value:, message:)
+      return default_error_streak_threshold
     end
 
     def parse_duration(value)

--- a/app/lib/tomato_shrieker/source.rb
+++ b/app/lib/tomato_shrieker/source.rb
@@ -390,6 +390,25 @@ module TomatoShrieker
       return Config.instance['/monitor/default_tolerance_seconds']
     end
 
+    # 何回連続で失敗したら異常とみなすか (#1558)。未指定ならグローバル値へ倒す。
+    #
+    # ⚠ **外部の安定度はソースの性質。**YouTube の /feeds/videos.xml は 24h で
+    # 7〜10% 失敗する（チャンネルは生きている）一方、GitHub の releases.atom は 0%。
+    # 同じしきい値で見ると、上げれば安定したソースの検知が鈍り、下げようもない。
+    # 🔴 **グローバル値だけだった間、この調整は Uptime Kuma の maxretries へ
+    # 漏れ出していた。**ソース定義を読んでも「何回で赤くなるか」が分からない
+    # 状態になるので、道具側に置く。
+    def monitor_error_streak_threshold
+      value = self['/monitor/error_streak_threshold']
+      return default_error_streak_threshold unless value.is_a?(Numeric)
+      return value.to_i if value.to_i.positive?
+      # 0 や負値は「1 回も失敗していなくても赤」になるだけなので、既定へ倒す
+      logger.warn(
+        source: id, key: 'monitor/error_streak_threshold', value:, message: 'not positive',
+      )
+      return default_error_streak_threshold
+    end
+
     # 無配信をどこまで許容するか (#1470)。
     # 未指定なら検知しない。chikanan のように年単位で正常に静かなソースがあるため、
     # 一律のデフォルトは置かず opt-in とする。
@@ -405,6 +424,10 @@ module TomatoShrieker
       # 不正値でこのソースだけを黙って無効化する。監視全体を巻き添えにしない。
       logger.error(source: id, key: 'monitor/silence_tolerance', value:, error: e)
       return nil
+    end
+
+    def default_error_streak_threshold
+      return Config.instance['/monitor/error_streak_threshold']
     end
 
     def parse_duration(value)

--- a/app/lib/tomato_shrieker/source_validator.rb
+++ b/app/lib/tomato_shrieker/source_validator.rb
@@ -34,8 +34,58 @@ module TomatoShrieker
         params = params.deep_stringify_keys
         return [] if params['disable'] == true
         return [] if params.dig('schedule', 'at')
-        return [] if params.dig('monitor', 'silence_tolerance')
-        return ['/monitor/silence_tolerance が未設定です。無配信が続いても検知されません']
+        messages = []
+        unless params.dig('monitor', 'silence_tolerance')
+          messages.push('/monitor/silence_tolerance が未設定です。無配信が続いても検知されません')
+        end
+        return messages.concat(unreachable_streak_warnings(params))
+      end
+
+      private
+
+      # 🔴 **しきい値に到達できない組み合わせを弾く（Codex P1・#1558）。**
+      #
+      # `error_streak` は `source_run_log` の行を数えるが、その行は
+      # `/monitor/retention_days` で prune される。⚠⚠ **実行間隔が疎なソースで
+      # しきい値を上げると、必要な本数の error 行が揃う前に古い行が消える**ため、
+      # **どれだけ連続で失敗しても 503 にならない**。
+      #
+      # 例: 月次 cron のソースにしきい値 3 を置くと、retention 14 日では
+      # 保護行＋直近の error しか残らず、永久に 2 未満のまま。⚠ `stale` も
+      # 助けにならない（run 自体は走っていて `executed_at` は前に進む）。
+      #
+      # ⚠ **NG ではなく WARN にする。**妥当な設定（15 分間隔 × 8 = 2 時間）と
+      # 見分けるのに実行間隔が要り、それはスキーマでは表現できない。
+      def unreachable_streak_warnings(params)
+        threshold = params.dig('monitor', 'error_streak_threshold')
+        return [] unless threshold.is_a?(Numeric) && threshold.to_i > 1
+        return [] unless seconds = schedule_interval_seconds(params)
+        days = (threshold.to_i * seconds / 86_400.0).ceil
+        retention = Config.instance['/monitor/retention_days']
+        return [] if days <= retention
+        return [
+          "/monitor/error_streak_threshold (#{threshold.to_i}) に到達するには約 #{days} 日ぶんの" \
+            " run が必要ですが、/monitor/retention_days は #{retention} 日です。" \
+            'prune で先に消えるため、連続して失敗しても 503 になりません',
+        ]
+      end
+
+      # 2 回続けて発火する間隔。⚠ **`at` のソースはここへ来ない**（呼び出し側で除外済み）。
+      #
+      # ⚠ 壊れた cron / period は nil を返す。**警告を出す処理が例外で倒れて
+      # `source validate` 全体を止めるほうが害が大きい**し、書式そのものの誤りは
+      # スキーマと起動時の register が別に捕まえる。
+      def schedule_interval_seconds(params)
+        schedule = params['schedule']
+        return nil unless schedule
+        if (cron = schedule['cron'])
+          first = Rufus::Scheduler.parse(cron).next_time(Time.now).to_t
+          return Rufus::Scheduler.parse(cron).next_time(first).to_t - first
+        end
+        return Rufus::Scheduler.parse(schedule['every']).to_i if schedule['every']
+        return nil
+      rescue StandardError
+        return nil
       end
     end
   end

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -55,7 +55,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/tomato-shrieker
-  version: 4.8.0
+  version: 4.9.0
 nostr:
   relays:
     - wss://relay.damus.io

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -69,6 +69,8 @@ properties:
       error_streak_threshold:
         # /healthz/source/:id を 503 にする連続エラー回数。未指定なら
         # /monitor/error_streak_threshold へ倒す（#1558）
+        # ⚠ 緩められるのはエントリを 1 件も読めていない失敗（取得失敗）だけ。
+        # エントリを読んだ後に落ちた失敗は、この値に関わらず 1 回で 503 になる
         type: integer
         minimum: 1
   keep:

--- a/config/schema/source.yaml
+++ b/config/schema/source.yaml
@@ -66,6 +66,11 @@ properties:
             minimum: 1
           - type: string
             pattern: '^((\d+(\.\d+)?[smhdwMy])+|\d+(\.\d+)?)$'
+      error_streak_threshold:
+        # /healthz/source/:id を 503 にする連続エラー回数。未指定なら
+        # /monitor/error_streak_threshold へ倒す（#1558）
+        type: integer
+        minimum: 1
   keep:
     type: object
     additionalProperties: false

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -461,7 +461,31 @@ monitor:
 
 ⚠⚠ **緩めても「本当に死んだら赤くなる」ことは変えない。**`cron: '0,15,30,45 * * * *'` なら 4 連続＝**1 時間で赤**。エラー率 7.3% なら 4 連続失敗の確率は 0.003% で、偽陽性はほぼ消える。
 
-⚠ **読む行数（`streak_window`）も一緒に広がる。**`sample_size` より大きいしきい値を書いても窓が足りず到達し得ない、という穴を作らないため。
+⚠ **読む行数（`streak_window`）も一緒に広がる。**`sample_size` より大きいしきい値を書いても窓が足りず到達し得ない、という穴を作らないため。⚠ **`/status.json` の `error_streak` も同じ窓で数える。**片方だけだと `error_streak: 50 / 100` という自己矛盾した数字が出る。
+
+🔴🔴 **しきい値 × 実行間隔が `/monitor/retention_days` を超えてはいけない。**`error_streak` が数えるのは `source_run_log` の行で、その行は prune で消える。⚠⚠ **疎なソースでしきい値を上げると、必要な本数の error 行が揃う前に古い行が消えるので、どれだけ連続で失敗しても 503 にならない。**⚠ `stale` も助けにならない（run 自体は走っていて `executed_at` は前に進む）。
+
+```
+月次 cron × しきい値 3 → 必要 90 日 > retention 14 日 → 永久に緑
+15 分間隔 × しきい値 8 → 必要 2 時間 ≪ retention 14 日 → 問題なし
+```
+
+⚠ **`bin/shrieker source validate` が WARN で指摘する。**NG にしないのは、妥当かどうかの判定に実行間隔が要り、**スキーマでは表現できない**ため。
+
+#### 🔴 緩められるのは「エントリを 1 件も読めていない失敗」だけ
+
+⚠⚠ **しきい値をいくつにしても、エントリを読んだ後に落ちた失敗は 1 回で 503 になる。**
+
+```
+フィード取得そのものが失敗（shrieker_errors 空）      → しきい値が効く
+エントリを読んだ後に失敗（shrieker_errors に source#fetch）→ 1 回で赤
+```
+
+🔴 **これが無いとエントリが恒久的に失われる。**`Entry.insert` は配信より先に走るので、`create_record` / `create_template` / `enclosures` / `Entry#shriek` 以降で落ちた run のエントリは **unique 制約で二度と取得されない**。しかもその失敗は `record_failure` 経由で `attempted_count` に載らないため、⚠⚠ **`undelivered` も `stale` も `silent` も立たず、`error_streak` が唯一のゲート**になっている（#1473 / `DeliveryStats#record_failure` のコメント）。
+
+📌 **run_log 上で 2 つの失敗族は既に区別できている。**`/status.json` の `shrieker_errors` と 503 本文を見れば、どちらの失敗なのか運用者にも分かる。
+
+⚠ **`/status.json` の `error_streak_threshold` は実効値。**1 に倒されているときは `1` が出る（宣言値ではない）。
 
 ⚠ **opt-in なので「書き忘れ」と「意図的に検知しない」が設定上は区別できない。**`bin/shrieker source validate` は監視対象なのに `silence_tolerance` が無いソースを `WARN` として出す（スキーマ上は妥当なので `NG` にはせず、終了コードも倒さない）。年単位で静かなソースは意図的に未設定のままでよい。
 
@@ -894,6 +918,8 @@ diff <(ssh oscura 'curl -s http://127.0.0.1:4567/status.json' | jq -r '.sources[
 ssh mucor 'sudo docker exec uptime-kuma sqlite3 -readonly /app/data/kuma.db \
   "select active, count(*) from monitor where name like \"tomato-shrieker %\" group by active;"'
 ```
+
+🔴 **ソース側へ `error_streak_threshold` を移したら、そのモニターの `maxretries` は 0 に戻す (#1558)。**⚠⚠ **両方残すと猶予が掛け算になる**（ソース側 N run × Kuma の再試行）。⚠ Kuma の登録は UI での手作業なので、移行は 1 セットで扱うこと。
 
 ⚠ **`interval` / `maxretries` のばらつきも読む。**⚠⚠ **ここに散らばりがあるのは、ソース側に置けない調整が Kuma へ漏れ出している印**（#1558）。2026-09-05 の実測は `interval` が 300s×35 / 900s×4 / 1800s×17、`maxretries` が 0×35 / 2×21 で、**2 が付いている 21 本＝ YouTube 4 本＋新規リポジトリ 17 本**＝外部が不安定なぶんを Kuma 側で吸収している。
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -261,7 +261,7 @@ scheduler プロセス生存 + DB 接続 + Rufus ジョブが 1 件以上、す�
 
 - 配信先が 1 つ以上ある (`dest_count > 0`)
 - 最終実行から `grace_seconds` 以内に走っている (stale でない)
-- 連続エラー回数が `/monitor/error_streak_threshold` 未満である
+- 連続エラー回数が `error_streak_threshold` 未満である（ソース単位で上書き可・#1558）
 - **直近の配信試行に取りこぼしが無い (undelivered でない)**
 - `silence_tolerance` を超えて無配信が続いていない (silent でない)
 
@@ -378,6 +378,7 @@ bin/shrieker source ack ID
       "last_delivered_at": "2026-04-14T14:00:01+09:00",
       "last_delivered_at_origin": "run_log",
       "error_streak": 0,
+      "error_streak_threshold": 1,
       "noop_streak": 0,
       "silence_tolerance_seconds": null,
       "silent": false,
@@ -425,7 +426,7 @@ Kuma からは見ない（人間が `curl | jq` する用、または外部ダ�
 | `/monitor/port` | `4567` | リッスンポート |
 | `/monitor/default_tolerance_seconds` | `7200` | ソース側の上書きが無いときの実行遅延の猶予 |
 | `/monitor/retention_days` | `14` | source_run_log の保持日数（自動 prune） |
-| `/monitor/error_streak_threshold` | `1` | `/healthz/source/:id` を 503 にする連続エラー回数 |
+| `/monitor/error_streak_threshold` | `1` | `/healthz/source/:id` を 503 にする連続エラー回数。**ソース側で上書き可** |
 | `/monitor/sample_size` | `50` | 統計・streak の算出に使う直近 run 件数 |
 
 ソース定義側で上書きできるキー:
@@ -434,6 +435,7 @@ Kuma からは見ない（人間が `curl | jq` する用、または外部ダ�
 |------|------|
 | `/monitor/tolerance` | 実行遅延の猶予。文字列なら `'30m'` のような Rufus 形式、数値なら秒。既定は `/monitor/default_tolerance_seconds` |
 | `/monitor/silence_tolerance` | 無配信の許容期間。**未指定ならサイレント不発を検知しない**（opt-in） |
+| `/monitor/error_streak_threshold` | 503 にする連続エラー回数。既定は `/monitor/error_streak_threshold`（#1558） |
 
 `silence_tolerance` はソースの性格に合わせて宣言する。年単位で正常に静かなソースに短い値を置くと過検知になる。**過検知は監視の信頼を壊す**ので、観測された最大の無配信間隔を上回る側に丸める。
 
@@ -443,6 +445,23 @@ monitor:
   tolerance: 30m
   silence_tolerance: 30d
 ```
+
+#### `error_streak_threshold` の上書き (#1558)
+
+⚠ **外部の安定度はソースの性質。**YouTube の `feeds/videos.xml` は**チャンネルが生きていても 24h で 7〜10% 失敗する**一方、GitHub の `releases.atom` は 0%。グローバル値だけだと、上げれば安定したソースの検知が鈍り、下げようもない。
+
+🔴 **グローバル値だけだった間、この調整は Uptime Kuma の `maxretries` へ漏れ出していた。**⚠ **ソース定義を読んでも「何回で赤くなるか」が分からない**状態になるので、道具側に置く。
+
+```yaml
+# 取得元が間欠的に失敗するソース
+monitor:
+  error_streak_threshold: 4
+  silence_tolerance: 90d
+```
+
+⚠⚠ **緩めても「本当に死んだら赤くなる」ことは変えない。**`cron: '0,15,30,45 * * * *'` なら 4 連続＝**1 時間で赤**。エラー率 7.3% なら 4 連続失敗の確率は 0.003% で、偽陽性はほぼ消える。
+
+⚠ **読む行数（`streak_window`）も一緒に広がる。**`sample_size` より大きいしきい値を書いても窓が足りず到達し得ない、という穴を作らないため。
 
 ⚠ **opt-in なので「書き忘れ」と「意図的に検知しない」が設定上は区別できない。**`bin/shrieker source validate` は監視対象なのに `silence_tolerance` が無いソースを `WARN` として出す（スキーマ上は妥当なので `NG` にはせず、終了コードも倒さない）。年単位で静かなソースは意図的に未設定のままでよい。
 

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -5,6 +5,8 @@ module TomatoShrieker
     FIXTURE_ID = '__test_monitor_app__'.freeze
     SILENT_ID = '__test_monitor_app_silent__'.freeze
     DISABLED_ID = '__test_monitor_app_disabled__'.freeze
+    # #1558: しきい値をソース単位で上書きしたソース
+    THRESHOLD_ID = '__test_monitor_app_threshold__'.freeze
 
     # teardown は異常終了で走らない。config/sources/.gitignore が `*` なので取り残しは
     # git status にも出ず、次のスケジューラ起動で偽ソースとして登録されてしまう。
@@ -15,17 +17,19 @@ module TomatoShrieker
 
     def setup
       @app = MonitorApp.new
-      SourceRunLog.where(source_id: [FIXTURE_ID, SILENT_ID]).delete
-      SilenceAck.where(source_id: [FIXTURE_ID, SILENT_ID]).delete
+      SourceRunLog.where(source_id: [FIXTURE_ID, SILENT_ID, THRESHOLD_ID]).delete
+      SilenceAck.where(source_id: [FIXTURE_ID, SILENT_ID, THRESHOLD_ID]).delete
       write_fixture(FIXTURE_ID, {})
       write_fixture(SILENT_ID, {'monitor' => {'silence_tolerance' => '1d'}})
+      write_fixture(THRESHOLD_ID, {'monitor' => {'error_streak_threshold' => 3}})
       config.reload
     end
 
     def teardown
-      SourceRunLog.where(source_id: [FIXTURE_ID, SILENT_ID, DISABLED_ID]).delete
-      SilenceAck.where(source_id: [FIXTURE_ID, SILENT_ID, DISABLED_ID]).delete
-      [FIXTURE_ID, SILENT_ID, DISABLED_ID].each {|id| FileUtils.rm_f(fixture_path(id))}
+      ids = [FIXTURE_ID, SILENT_ID, DISABLED_ID, THRESHOLD_ID]
+      SourceRunLog.where(source_id: ids).delete
+      SilenceAck.where(source_id: ids).delete
+      ids.each {|id| FileUtils.rm_f(fixture_path(id))}
       super # TestCase#teardown が config.reload する
     end
 
@@ -161,6 +165,53 @@ module TomatoShrieker
       assert_include(body.first, 'error_streak: 1')
       # 「エラーメッセージの無い 503」を運用者に見せない
       assert_include(body.first, 'RuntimeError: boom')
+    end
+
+    # #1558: しきい値をソース単位で上げたソースは、下回るあいだ緑のまま。
+    # ⚠ **YouTube の /feeds/videos.xml は 24h で 7〜10% 失敗する**ので、グローバルの
+    # 1 では正常時も Kuma が頻繁に赤くなり、監視ごと信用されなくなる。
+    def test_healthz_source_tolerates_errors_below_threshold
+      # ⚠ **attempted_count は 0。**フィード取得の失敗は宛先へ試行する前に落ちるので、
+      # これが実際の YouTube の形。1 にすると undelivered (#1504) が別経路で 503 にする。
+      2.times do |i|
+        record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+          error_message: 'Bad response 404', at: Time.now - (120 - (i * 10)))
+      end
+      status, = call("/healthz/source/#{THRESHOLD_ID}")
+
+      assert_equal(2, SourceRunLog.error_streak(THRESHOLD_ID))
+      assert_equal(200, status)
+    end
+
+    # しきい値に届けば赤になる。⚠ **緩めても「本当に死んだら赤くなる」ことは変えない。**
+    def test_healthz_source_errored_at_source_threshold
+      3.times do |i|
+        record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+          error_message: 'Bad response 404', at: Time.now - (120 - (i * 10)))
+      end
+      status, _headers, body = call("/healthz/source/#{THRESHOLD_ID}")
+
+      assert_equal(503, status)
+      # 「何回で赤くなるのか」を本文で答える
+      assert_include(body.first, 'error_streak: 3 / 3')
+    end
+
+    # ⚠ 上書きしていないソースは従来どおりグローバル値（1）で倒れる
+    def test_healthz_source_threshold_does_not_leak_to_other_sources
+      record(FIXTURE_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+        error_message: 'Bad response 404')
+      status, = call("/healthz/source/#{FIXTURE_ID}")
+
+      assert_equal(503, status)
+    end
+
+    # #1558: 「なぜこのソースはまだ緑なのか」を /status.json から説明できること
+    def test_status_json_exposes_error_streak_threshold
+      assert_equal(3, source_status(THRESHOLD_ID)['error_streak_threshold'])
+      assert_equal(
+        Config.instance['/monitor/error_streak_threshold'],
+        source_status(FIXTURE_ID)['error_streak_threshold'],
+      )
     end
 
     # 配信できた success が来れば streak は切れて健全に戻る

--- a/test/monitor_app.rb
+++ b/test/monitor_app.rb
@@ -162,7 +162,7 @@ module TomatoShrieker
       status, _headers, body = call("/healthz/source/#{FIXTURE_ID}")
 
       assert_equal(503, status)
-      assert_include(body.first, 'error_streak: 1')
+      assert_include(body.first, 'error_streak: 1 / 1')
       # 「エラーメッセージの無い 503」を運用者に見せない
       assert_include(body.first, 'RuntimeError: boom')
     end
@@ -203,6 +203,95 @@ module TomatoShrieker
       status, = call("/healthz/source/#{FIXTURE_ID}")
 
       assert_equal(503, status)
+    end
+
+    # 🔴 **しきい値を広げたら読む行数も広がること（Codex P1 / レビュー R1）。**
+    # ⚠ これが無いと `limit: streak_window(threshold)` を消してもテストが通る。
+    # sample_size を一時的に小さくして、窓が sample_size 止まりでないことを見る。
+    def test_healthz_source_threshold_widens_streak_window
+      with_sample_size(2) do
+        3.times do |i|
+          record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+            error_message: 'Bad response 404', at: Time.now - (120 - (i * 10)))
+        end
+        status, = call("/healthz/source/#{THRESHOLD_ID}")
+
+        assert_equal(503, status)
+      end
+    end
+
+    # /status.json 側も同じ窓で数えること。⚠ 片方だけだと 503 にしている当人が
+    # `error_streak: 2 / 3` という自己矛盾した数字を出す
+    def test_status_json_uses_source_threshold_window
+      with_sample_size(2) do
+        3.times do |i|
+          record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+            error_message: 'Bad response 404', at: Time.now - (120 - (i * 10)))
+        end
+
+        assert_equal(3, source_status(THRESHOLD_ID)['error_streak'])
+      end
+    end
+
+    # ⚠⚠ **streak 以外の指標は sample_size で切ること (#1558)。**広い窓のまま
+    # 数えると 503 本文（sample_size 固定）と /status.json が違う数字を出す
+    def test_status_json_keeps_sample_size_for_other_metrics
+      with_sample_size(2) do
+        3.times do |i|
+          record(THRESHOLD_ID, attempted_count: 0, at: Time.now - (120 - (i * 10)))
+        end
+
+        assert_equal(2, source_status(THRESHOLD_ID)['noop_streak'])
+      end
+    end
+
+    # 🔴🔴 **エントリを読んだ後に落ちた失敗は、しきい値を緩めていても 1 回で赤。**
+    # 緩めるとそのぶんのエントリが恒久的に失われるのに undelivered / stale / silent の
+    # どれも立たない (#1473)。run_log 上は shrieker_errors の有無で区別できる
+    def test_healthz_source_entry_level_failure_ignores_threshold
+      record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+        error_message: 'RuntimeError: template broken',
+        shrieker_errors: JSON.dump({'source#fetch' => 1}))
+      status, _headers, body = call("/healthz/source/#{THRESHOLD_ID}")
+
+      assert_equal(503, status)
+      # しきい値 3 を宣言していても 1 で倒す
+      assert_include(body.first, 'error_streak: 1 / 1')
+    end
+
+    # ⚠ 取得そのものの失敗（shrieker_errors 空）はこれまでどおり緩和が効く
+    def test_healthz_source_fetch_failure_keeps_threshold
+      2.times do |i|
+        record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+          error_message: 'Bad response 404', at: Time.now - (120 - (i * 10)))
+      end
+      status, = call("/healthz/source/#{THRESHOLD_ID}")
+
+      assert_equal(200, status)
+    end
+
+    # 🔴 **/status.json も実効値を出すこと（レビュー R1）。**宣言値を出すと
+    # /healthz が `1 / 1` で 503 なのに /status.json は `3` と言う
+    def test_status_json_exposes_effective_threshold
+      record(THRESHOLD_ID, status: SourceRunLog::STATUS_ERROR, attempted_count: 0,
+        error_message: 'RuntimeError: template broken',
+        shrieker_errors: JSON.dump({'source#fetch' => 1}))
+      status = source_status(THRESHOLD_ID)
+
+      assert_equal(1, status['error_streak_threshold'])
+      assert_equal(1, status['error_streak'])
+    end
+
+    def with_sample_size(size)
+      key = config.basenames.find {|v| config.raw.key?(v)}
+      original = config.raw[key]['monitor']
+      config.raw[key]['monitor'] = (original || {}).deep_dup
+      config.raw[key]['monitor']['sample_size'] = size
+      config.reload
+      yield
+    ensure
+      config.raw[key]['monitor'] = original
+      config.reload
     end
 
     # #1558: 「なぜこのソースはまだ緑なのか」を /status.json から説明できること

--- a/test/source.rb
+++ b/test/source.rb
@@ -390,6 +390,29 @@ module TomatoShrieker
       assert_equal(600, source.monitor_silence_tolerance_seconds)
     end
 
+    # #1558: error_streak_threshold は未指定ならグローバル値へ倒す。
+    # ⚠ silence_tolerance と違い opt-out ではなく「既定つきの上書き」。
+    def test_monitor_error_streak_threshold
+      global = Config.instance['/monitor/error_streak_threshold']
+
+      assert_equal(global, Source.new({'id' => 'test-streak-unset'}).monitor_error_streak_threshold)
+      source = Source.new({'id' => 'test-streak-set', 'monitor' => {'error_streak_threshold' => 4}})
+
+      assert_equal(4, source.monitor_error_streak_threshold)
+    end
+
+    # ⚠ 0 や負値は「1 回も失敗していなくても赤」になるだけなので既定へ倒す。
+    # スキーマ (minimum: 1) を通らない値だが、スキーマは load 時に当たらない
+    # （source edit / source validate だけ）ので実行時に来うる。
+    def test_monitor_error_streak_threshold_rejects_non_positive
+      global = Config.instance['/monitor/error_streak_threshold']
+      [0, -1].each do |value|
+        source = Source.new({'id' => 'test-streak-bad', 'monitor' => {'error_streak_threshold' => value}})
+
+        assert_equal(global, source.monitor_error_streak_threshold, "value=#{value}")
+      end
+    end
+
     SILENT_ID = '__test_source_silent__'.freeze
 
     def silent_source(extra = {})

--- a/test/source.rb
+++ b/test/source.rb
@@ -406,6 +406,13 @@ module TomatoShrieker
     # （source edit / source validate だけ）ので実行時に来うる。
     def test_monitor_error_streak_threshold_rejects_non_positive
       global = Config.instance['/monitor/error_streak_threshold']
+      # ⚠ 文字列は受けない。silence_tolerance は Rufus の duration を受けるので
+      # 書き方が非対称だが、回数に単位は無いので整数だけに絞る
+      ['4', '3d', true].each do |value|
+        source = Source.new({'id' => 'test-streak-str', 'monitor' => {'error_streak_threshold' => value}})
+
+        assert_equal(global, source.monitor_error_streak_threshold, "value=#{value.inspect}")
+      end
       [0, -1].each do |value|
         source = Source.new({'id' => 'test-streak-bad', 'monitor' => {'error_streak_threshold' => value}})
 

--- a/test/source_run_log.rb
+++ b/test/source_run_log.rb
@@ -270,6 +270,16 @@ module TomatoShrieker
       assert_operator(SourceRunLog.streak_window, :>=, SourceRunLog.sample_size)
     end
 
+    # #1558: しきい値はソース単位で上書きできる。⚠ **窓も一緒に広げないと、
+    # しきい値だけ大きくしても到達し得ないまま健全扱いになる。**
+    def test_streak_window_covers_source_threshold
+      wide = SourceRunLog.sample_size + 10
+
+      assert_operator(SourceRunLog.streak_window(wide), :>=, wide)
+      # 小さい上書きで窓を狭めない（sample_size は他の集計も使う）
+      assert_equal(SourceRunLog.sample_size, SourceRunLog.streak_window(1))
+    end
+
     # #1470: 配信ゼロが続いた回数。エラー run も数に入れる
     def test_noop_streak
       create_logs(

--- a/test/source_validator.rb
+++ b/test/source_validator.rb
@@ -130,6 +130,80 @@ module TomatoShrieker
 
     # #1470: silence_tolerance は opt-in なのでスキーマ上は妥当だが、
     # 宣言しなければサイレント不発の検知が丸ごと効かない
+    # 🔴 **スキーマ項目そのものを守る（レビュー R2 / M12）。**monitor は
+    # additionalProperties: false なので、この項目が消えた瞬間に docs に書いた
+    # 設定例が source validate / source edit で弾かれる。⚠ それを検知するテストが無かった。
+    def test_valid_monitor_error_streak_threshold
+      base = {
+        'source' => {'feed' => 'https://example.com/feed'},
+        'dest' => {'hooks' => ['https://example.com/x']},
+      }
+
+      assert_true(SourceValidator.valid?(base.merge('monitor' => {'error_streak_threshold' => 4})))
+      assert_true(SourceValidator.valid?(base.merge('monitor' => {'error_streak_threshold' => 28})))
+      # minimum: 1 / type: integer
+      assert_false(SourceValidator.valid?(base.merge('monitor' => {'error_streak_threshold' => 0})))
+      assert_false(SourceValidator.valid?(base.merge('monitor' => {'error_streak_threshold' => '4'})))
+    end
+
+    # 🔴 Codex P1 (#1558): しきい値に到達するのに retention_days より長くかかる
+    # 組み合わせを弾く。⚠ **どれだけ連続で失敗しても 503 にならない**設定になる。
+    def test_warnings_unreachable_error_streak_threshold
+      retention = Config.instance['/monitor/retention_days']
+      daily = {
+        'source' => {'feed' => 'https://example.com/feed'},
+        'schedule' => {'cron' => '1 0 * * *'},
+        'dest' => {'hooks' => ['https://example.com/x']},
+        'monitor' => {'silence_tolerance' => '7d'},
+      }
+
+      # 日次 × retention+1 回ぶん = 窓に入らない
+      warnings = SourceValidator.warnings(
+        daily.merge('monitor' => {'silence_tolerance' => '7d',
+                                  'error_streak_threshold' => retention + 1}),
+      )
+
+      assert_equal(1, warnings.size)
+      assert_match(/error_streak_threshold/, warnings.first)
+      assert_match(/retention_days/, warnings.first)
+
+      # 日次 × retention 回ぶんなら収まる
+      assert_empty(SourceValidator.warnings(
+        daily.merge('monitor' => {'silence_tolerance' => '7d',
+                                  'error_streak_threshold' => retention}),
+      ))
+      # ⚠ 既定（未指定）と 1 は指摘しない
+      assert_empty(SourceValidator.warnings(daily))
+      assert_empty(SourceValidator.warnings(
+        daily.merge('monitor' => {'silence_tolerance' => '7d', 'error_streak_threshold' => 1}),
+      ))
+    end
+
+    # 15 分間隔ならしきい値を大きくしても収まる（本番の YouTube 系がこれ）
+    def test_warnings_frequent_source_tolerates_large_threshold
+      source = {
+        'source' => {'feed' => 'https://example.com/feed'},
+        'schedule' => {'cron' => '0,15,30,45 * * * *'},
+        'dest' => {'hooks' => ['https://example.com/x']},
+        'monitor' => {'silence_tolerance' => '90d', 'error_streak_threshold' => 8},
+      }
+
+      assert_empty(SourceValidator.warnings(source))
+    end
+
+    # ⚠ 壊れた schedule で警告の算出が倒れて validate 全体を止めない
+    def test_warnings_survive_broken_schedule
+      source = {
+        'source' => {'feed' => 'https://example.com/feed'},
+        'schedule' => {'cron' => 'not a cron'},
+        'dest' => {'hooks' => ['https://example.com/x']},
+        'monitor' => {'silence_tolerance' => '7d', 'error_streak_threshold' => 999},
+      }
+
+      assert_nothing_raised {SourceValidator.warnings(source)}
+      assert_empty(SourceValidator.warnings(source))
+    end
+
     def test_warnings_silence_tolerance_unset
       base = {
         'source' => {'feed' => 'https://example.com/feed'},


### PR DESCRIPTION
**v4.9.0。**⚠ **スコープは #1558 の 1 件だけ。**「YouTube 系が正常時も Kuma で頻繁に赤くなり、監視として役に立たなくなっている」という実害を止めるために、他 8 件を 4.10.0 へ送って先に出します。

## 🔴 何を直すか

`error_streak_threshold` がグローバルの `1` だけで、**1 回失敗しただけで `/healthz/source/:id` が 503**。本番の実害（Kuma・7 日間）:

| モニター | up | pending | **down** | down 率 |
|---|---:|---:|---:|---:|
| `chikanan` | 126 | 12 | **44** | **24%** |
| `precure-petitcure-youtube` | 138 | 9 | **36** | **20%** |
| `vjump-youtube` | 134 | 11 | **31** | **18%** |
| `precure-youtube` | 137 | 20 | **25** | **14%** |

⚠ **これは Kuma 側で `maxretries: 2` を噛ませた後の数字。**

## 🔴 原因は「間欠的な 404」ではなかった（#1582 を起票）

レビューで実データを当てたところ、**毎日決まった時間帯の全滅**でした。

| 時刻 (JST) | 00–09 | 10 | 11 | **12** | **13** | 14 | **15** | 16 | 17–23 |
|---|---|---|---|---|---|---|---|---|---|
| エラー率 | **0.0%** | 5.4% | 25.9% | **56.3%** | **58.0%** | 47.7% | **51.8%** | 2.7% | **0.0%** |

⚠⚠ **1 日 17 時間はエラーがちょうど 0 件。**しかも 2026-09-05 に cron を `every: 5m` → 15 分間隔 4 本の位相ずらしにしたのに、**窓内のエラー率は 4 本すべてで上がった**（`chikanan` 24.1% → 44.6%）。**「同一 IP からの 4 並列が弾かれている」という前提は実データで否定**されます → **#1582**。🔴 **#1557（位相分散）の根拠も崩れている**ので 4.10.0 に送ってあります。

## 変更

```yaml
monitor:
  error_streak_threshold: 28
  silence_tolerance: 90d
```

- `Source#monitor_error_streak_threshold`。`silence_tolerance` と同じ書き方・同じ粒度で、未指定ならグローバル値へ
- ⚠ 読む行数（`streak_window`）も解決した値に従わせる。**`/status.json` も同じ窓・同じ実効値**を出す
- 🔴 **緩められるのは「エントリを 1 件も読めていない失敗」だけ**（下記）
- `config/schema/source.yaml` に追加。⚠ `source validate` が**到達できないしきい値**を WARN で弾く

## 🔴 carve-out: エントリを読んだ後の失敗は 1 回で赤

⚠⚠ **これが無いとエントリが恒久的に失われます。**`Entry.insert` は配信より先に走るので、`create_record` / `create_template` / `enclosures` / `Entry#shriek` 以降で落ちた run のエントリは **unique 制約で二度と取得されない**。しかもその失敗は `record_failure` 経由で `attempted_count` に載らないため **`undelivered` も `stale` も `silent` も立たず、`error_streak` が唯一のゲート**（#1473）。

📌 **run_log 上で 2 つの失敗族は既に区別できている**（取得失敗は `shrieker_errors` 空、エントリ単位は `source#fetch` が載る）ので、そこで切り分けました。**仕様は 1 行で言えます。**

## ✅ リリース前検証: 本番データを実コードで再生した

`oscura` の `source_run_log` をコピーし、**`error_streak_of` / `entry_level_error?` の実コード**でしきい値ごとの 503 エピソード数を数えました（cron 変更後の 7 日・各 674 run）。

| source | runs | T=1 | T=6/8（当初案） | T=20 | **T=28（採用）** |
|---|---:|---:|---:|---:|---:|
| `chikanan` | 674 | 21 | 5 | 0 | **0** |
| `vjump-youtube` | 674 | 17 | 5 | 0 | **0** |
| `precure-youtube` | 674 | 23 | 2 | 0 | **0** |
| `precure-petitcure-youtube` | 674 | 20 | 3 | 0 | **0** |
| **合計** | | **81** | **15** | **0** | **0** |

🔴 **当初の案（chikanan 8 / 他 6）では週 15 回鳴り続ける**ことが分かったので 28 にしました。観測された最大連続エラーは 16（`chikanan`・09-11 10:27〜14:12）で、**28 = 窓 7 時間ぶん（15 分 × 28）**です。

✅ **この 4 本は `shrieker_errors` 非空の run が 0 件** ＝ 全部が取得失敗で、carve-out が邪魔をしないことも確認しました。

⚠⚠ **緩めても「壊れたら気づかない」にはなりません。**取得が恒久的に失敗すれば streak は無限に伸びるので **7 時間で必ず到達**し、スケジューラが止まれば `stale` が **2 時間 15 分**で独立に 503 にします。`silence_tolerance: 90d` も別の網として残ります。

## リリース前レビュー（5 観点 + Codex）

**5 観点すべてと Codex が独立に指摘を出し、🔴 を 4 件修正しました。**

| 出どころ | 指摘 | 対応 |
|---|---|---|
| 監視セマンティクス 🔴 | 緩和でエントリが恒久的に失われる経路（4 判定のどれでも捕まらない） | carve-out を実装 |
| Codex P1 🔴 | `しきい値 × 実行間隔 > retention_days` だと prune で行が消え**永久に緑** | `source validate` の WARN |
| Codex P2 / 設定・スキーマ 🔴 | `/status.json` が窓と**宣言値**を出し、`/healthz` の 503 と食い違う | 同じ窓・実効値に |
| 運用リスク 🔴 | rubocop 1 件で CI が赤 | 修正 |
| 値の妥当性 🔴 | **当初値が観測最大の約半分**。独立試行の前提が誤り | 28 へ・#1582 起票 |

⚠ **エージェント同士が食い違った点はありません**が、**「値」観点と「運用リスク」観点が独立に同じ 🔴（当初値では足りない）を検出**しました。

## 検証

- ✅ `bundle exec rake test` → **302 tests / 1065 assertions / 0 failures / 0 errors / 12 omissions**（+17 tests）
- ✅ `bundle exec rubocop` → **94 files / no offenses**
- ✅ **8 箇所を個別に壊して全部赤くなることを確認**（窓の追従・carve-out・実効値・統計窓の切り出し・`streak_window` の引数・非整数ガード・非正値ガード・スキーマ項目）
- ✅ マイグレーション不要（`app/migration/` 差分ゼロ）
- ✅ **デプロイ直後（ソース定義に何も書かない状態）は 4.8.0 と完全に同一**の判定
- ✅ Wiki「監視」を追従済み

## デプロイ後の作業

1. 4 本に `error_streak_threshold: 28` を入れる（⚠ `config/sources/` は本番にしかない）
2. `bin/shrieker source validate` → `bin/shrieker source reload`
3. `/status.json` で確認: `jq '.sources[]|select(.error_streak_threshold!=1)|{id,error_streak,error_streak_threshold}'`
4. ⚠ **Kuma 側の `maxretries` を 2 → 0 に戻す**（UI 手作業・両方残すと猶予が掛け算）

## ⚠ 他の open PR への影響

- **#1576**（ginseng-* の版固定・base: main）は**このマージ後に rebase が必要**
- **#1581**（docs を 5 本へ分割）は `docs/CLAUDE.md` が競合するので **rebase が必要**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
